### PR TITLE
Add dsh-model-router to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The hottest category — giving text-only models "eyes."
 | [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) | Skill-driven harness/loop engineering workflow agent plugin | 43 |
 | [weshopai/weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) | Native WeShop plugin: infinite canvas with infinite creative skills | 6 |
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
+| [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 0 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -118,6 +118,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) | Skill 驱动的 Harness/Loop 工程工作流 Agent 插件 | 43 |
 | [weshopai/weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) | 原生 WeShop 插件:无限画布 + 无限创意技能 | 6 |
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
+| [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 0 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
Adds `dsh-model-router` to the Tools, Workflows & Presets table in both README.md and README.zh.md.

**Relationship to DSH:** dsh-model-router is a DeepSeek Harness (dsh) plugin. It enforces role-based model routing — the planner (root agent) runs on `deepseek-v4-pro` and every delegated executor subagent runs on `deepseek-v4-flash` — plus an always-on prompt section and a `pro-flash-routing` skill. Installed with:

`dsh plugin --profile web add git+https://github.com/thedeveloper256/dsh-model-router`

MIT license, TypeScript, live-verified against the harness (planner requests log `deepseek-v4-pro`, executor subagents log `deepseek-v4-flash`), tagged `v0.1.0`.
