### PR TITLE
add: zizaiwo/dsh_plugins — 侧边栏会话分类插件

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The hottest category — giving text-only models "eyes."
 | [Nagi-ovo/dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | Render interactive visualization cards inside DSH conversations | 88 |
 | [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) | GenUI: interactive UI components inline in replies (layout, charts, forms, mermaid, 3D) + action event loop | 87 |
 | [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | OpenPencil design preview & editing plugin for DSH | 71 |
+| [zizaiwo/dsh_plugins](https://github.com/zizaiwo/dsh_plugins) | dsh 侧边栏会话分类插件：零配置接管官方工作区浏览器，按自定义分类文件夹管理会话（拖拽归类/分类内建会话/每工作区独立） | 0 |
 
 ### 🖥️ TUI & Desktop
 


### PR DESCRIPTION
## 收录内容

在 Web UI 分类添加 [zizaiwo/dsh_plugins](https://github.com/zizaiwo/dsh_plugins)：

- **dsh-session-categories**：dsh 侧边栏会话分类插件（fork 官方 ui-workspace，零配置接管，按分类文件夹管理会话）
- 已打 \dsh-plugin\ topic
- npm 已发布：\@zizaiwo/dsh-session-categories\

## 与 DSH 的关系

插件 fork 官方 \@deepseek-ai/dsh-client-ui-workspace\，注册同一 sidebar slot 并自动禁用官方条目，为 dsh Web UI 增加会话分类能力。