### PR TITLE
Add dsh-office-for-mso: DSH <-> Microsoft Office bridge skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The hottest category — giving text-only models "eyes."
 | [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | 85 SKILL.md reverse-engineering & security research skill pack (Cordis plugin) | 10 |
 | [Lyn-77/ProMentor](https://github.com/Lyn-77/ProMentor) | AI coding mentor: architecture scan, laddered chapters, hand-written core logic, auto-grading | 54 |
 | [Jayden-X-L/forkprobe](https://github.com/Jayden-X-L/forkprobe) | Compare multiple skills on the same task and pick the winner | 65 |
+| [Mikuzjc/dsh-office-for-mso](https://github.com/Mikuzjc/dsh-office-for-mso) | DSH <-> Microsoft Office bridge skill: control open Word/Excel/PowerPoint via Office add-in (33 actions, AI-orchestrated) | 0 |
 | [morluto/rea](https://github.com/morluto/rea) | Reverse engineer anything with agents, from app behavior down to native binaries | 322 |
 
 ### 🚀 Apps & Runtimes Built on DSH


### PR DESCRIPTION
## What
Add [dsh-office-for-mso](https://github.com/Mikuzjc/dsh-office-for-mso) to the Skills section — a DeepSeek Harness (DSH) plugin/skill that lets AI control the user's **currently open** Word/Excel/PowerPoint documents through an Office add-in.

## Highlights
- 33 actions: read/write documents & tables, formatting, chart generation, formula evaluation, comments, sort/filter, worksheet management
- One-command install (\
pm run setup\): persistent background service + auto-registered add-in (Windows)
- Multi-document host routing (Word/Excel/PPT in parallel)
- dryRun safety guardrails for destructive ops
- Trilingual docs (EN/JA/ZH), MIT license, includes SKILL.md skill pack
- Tagged with \dsh-plugin\ topic