### PR TITLE
Add dsh-better-stats plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The hottest category — giving text-only models "eyes."
 | [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) | Self-evolving plugin: hot-mount/remove Cordis plugins in-session, auto-restore on restart | 5 |
 | [Francis-Xavier-code/dsh-balance-plugin](https://github.com/Francis-Xavier-code/dsh-balance-plugin) | DeepSeek balance monitoring & usage stats + official top-up entry | 7 |
 | [Cassius0924/dsh-usage-dashboard](https://github.com/Cassius0924/dsh-usage-dashboard) | DeepSeek quota & usage dashboard | 4 |
+| [null5069/dsh-better-stats](https://github.com/null5069/dsh-better-stats) | Enhanced DSH Web composer stats strip: official CNY pricing (peak/off-peak, per-model), real-time settlement, live LLM/tool timers, provider balance, budget alerts | 2 |
 | [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | AgentTeams multi-agent collaboration plugin for DSH | 290 |
 | [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) | Skill-driven harness/loop engineering workflow agent plugin | 43 |
 | [weshopai/weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) | Native WeShop plugin: infinite canvas with infinite creative skills | 6 |

--- a/README.zh.md
+++ b/README.zh.md
@@ -114,6 +114,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) | 自进化插件:session 内热挂载/卸载 Cordis 插件,重启自动恢复 | 5 |
 | [Francis-Xavier-code/dsh-balance-plugin](https://github.com/Francis-Xavier-code/dsh-balance-plugin) | DeepSeek 余额监控与用量统计 + 官方充值入口 | 7 |
 | [Cassius0924/dsh-usage-dashboard](https://github.com/Cassius0924/dsh-usage-dashboard) | DeepSeek 额度与用量仪表盘 | 4 |
+| [null5069/dsh-better-stats](https://github.com/null5069/dsh-better-stats) | DSH Web 输入框增强统计条：官方 CNY 计价（峰谷时段、分模型）、实时结算、LLM/工具实时计时、余额直连、预算预警 | 2 |
 | [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | AgentTeams 多代理协作插件 | 290 |
 | [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) | Skill 驱动的 Harness/Loop 工程工作流 Agent 插件 | 43 |
 | [weshopai/weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) | 原生 WeShop 插件:无限画布 + 无限创意技能 | 6 |


### PR DESCRIPTION
## 新增：dsh-better-stats

在 `🧩 Tools, Workflows & Presets` 分类（与 dsh-balance-plugin、dsh-usage-dashboard 相邻）添加 [null5069/dsh-better-stats](https://github.com/null5069/dsh-better-stats)，README.md 与 README.zh.md 同步更新。

**与 DSH 的关系：** 标准 `dsh.bundle`（cordis.patch.yml）Web 平台插件，host + client 双入口，`dsh plugin --profile web add dsh-better-stats` 一键安装（npm 已发布 v0.1.15，预构建免构建授权）。功能：官方 CNY 计价（峰谷分时、价目自动同步、按模型分账）、实时 LLM/工具计时、agent-team 子代理树合并结算、DeepSeek 余额直连（凭据走 host 不进浏览器）、预算/余额预警、流式成本估算；中英双语 UI，MIT，零运行时依赖，仓库已打 `dsh-plugin` topic。