### PR TITLE
docs: add lcsdg/dsh-quick-prompts to Web UI, Skins & Desktop Pets

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The hottest category — giving text-only models "eyes."
 | [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) | GenUI: interactive UI components inline in replies (layout, charts, forms, mermaid, 3D) + action event loop | 87 |
 | [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | OpenPencil design preview & editing plugin for DSH | 71 |
 
+| [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) | 输入框上方的快捷指令胶囊栏：按分类存常用 prompt，橙色高亮占位符，两栏管理，分类记忆按会话独立持久化 | 0 |
 ### 🖥️ TUI & Desktop
 
 | Project | Description | ⭐ |


### PR DESCRIPTION
Add [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) to **🎨 Web UI, Skins & Desktop Pets**.

**Relation to DSH**: a front-end dsh plugin that adds a quick-prompts bar above the composer — per-category snippet chips, orange `{{placeholder}}` highlighting, two-column prompt/category management, and per-session category memory.

Tagged with the `dsh-plugin` topic and published on npm as `@max1997/dsh-quick-prompts` (install: `dsh plugin --profile web add @max1997/dsh-quick-prompts`).