### PR TITLE
Add dsh-plus-plus (Windows WPF desktop console) to TUI & Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The hottest category — giving text-only models "eyes."
 | [vibeinging/deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | Local AI desktop workspace: sessions, projects, files, web research, plugins, Office artifacts | 111 |
 | [ChisaAlter/Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | Electron desktop shell for the DSH web UI, with themes & backgrounds | 74 |
 | [Ruler4396/dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Lightweight Windows launcher: silent autostart + WebView2 window | 87 |
+| [Jensen-Yao/dsh-plus-plus](https://github.com/Jensen-Yao/dsh-plus-plus) | Windows WPF desktop console for `dsh web`: one-click start/stop, phone URL over Wi-Fi/domain/Tailscale, firewall rule, storage locations, live logs, dark/light themes | 0 |
 
 ### 🧩 Tools, Workflows & Presets
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -97,6 +97,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [vibeinging/deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 本地 AI 桌面工作区:Sessions、项目、文件、网页研究、插件、Office 工件 | 111 |
 | [ChisaAlter/Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | DSH Web UI 的 Electron 桌面壳,支持主题与背景图 | 74 |
 | [Ruler4396/dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows 轻量启动器:开机静默自启 + WebView2 窗口 | 87 |
+| [Jensen-Yao/dsh-plus-plus](https://github.com/Jensen-Yao/dsh-plus-plus) | Windows WPF 桌面控制台：一键启停 dsh web、手机入口（同一 Wi-Fi/自定义域名/Tailscale）、防火墙放行、存储位置管理与实时日志，深浅双主题 | 0 |
 
 ### 🧩 工具、工作流与预设
 


### PR DESCRIPTION
## What is it

**[dsh++](https://github.com/Jensen-Yao/dsh-plus-plus)** — a Windows WPF desktop console for \dsh web\.

## Relationship to DSH

- Directly drives the official \@deepseek-ai/dsh\ CLI: one-click start/stop of \dsh web\, port and bind-address management (0.0.0.0 vs 127.0.0.1 via \--patch\ overlay), live log tailing of the dsh process
- Manages dsh storage locations (settings / sessions / storages / profiles / skills / agent-presets, plus \DSH_HOME\ / \DSH_AGENTS_HOME\) from a GUI
- Generates the phone entry URL (same Wi-Fi / custom domain with \--trusted-host\ / Tailscale ts.net), one-click firewall rule, and disables the pairing gate (\equirePairingForLan\) so phones can open the same session — including streaming thoughts
- Injects a browser-compat polyfill into the web frontend dist; re-injects automatically after npm upgrades
- MIT, public repo, tagged \dsh-plugin\, prebuilt release: https://github.com/Jensen-Yao/dsh-plus-plus/releases/tag/v2.0.0

## Changes

- One row added to **🖥️ TUI & Desktop** in README.md and README.zh.md (star count 0 — repo just published)