### PR TITLE
Add zhengjy01/dsh-task-dispatcher (TickTick daily task dispatcher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The hottest category — giving text-only models "eyes."
 | [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) | Skill-driven harness/loop engineering workflow agent plugin | 43 |
 | [weshopai/weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) | Native WeShop plugin: infinite canvas with infinite creative skills | 6 |
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
+| [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick (滴答清单) daily task dispatcher: interval pulls of today's due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
 
 ### 📚 Skills
 


### PR DESCRIPTION
Add **dsh-task-dispatcher** under **🧩 Tools, Workflows & Presets** in the README table.

**dsh-task-dispatcher** — TickTick (滴答清单) daily task dispatcher for DeepSeek Harness:
- interval-based pulls of today's due tasks from the 5️⃣AI list
- change-aware flomo + macOS notifications
- optional auto-execute (one headless DSH session per task)
- worker workspace selection
- dispatcher_report flomo summary tool
- web task board

npm: dsh-task-dispatcher@0.1.0 · topics: dsh-plugin / deepseek-harness / ticktick