### PR TITLE
test: curator auto checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The hottest category — giving text-only models "eyes."
 | [zizaiwo/dsh_plugins](https://github.com/zizaiwo/dsh_plugins) | Sidebar session categories for dsh Web UI: zero-config takeover of official workspace browser, organize sessions by custom folders (drag & drop, in-category creation, per-workspace isolation) | 0 |
 | [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) | Quick-prompts bar above composer: per-category snippet chips, orange {{placeholder}} highlighting, two-column management, per-session category memory | 0 |
 | [Moonshile/moonshile-dsh-plugins](https://github.com/Moonshile/moonshile-dsh-plugins) | Re-sorts sidebar workspaces by last activity once per day; stable order within the day | 0 |
+| [test/test-plugin-demo](https://github.com/test/test-plugin-demo) | Demo plugin for curator test — should be flagged and not merged | 0 |
 ### 🖥️ TUI & Desktop
 
 | Project | Description | ⭐ |


### PR DESCRIPTION
Test PR for curator — please keep open for 2 min to see bot labels/comments, then close.

Repo: test/test-plugin-demo (fake, should be flagged as missing dsh-plugin, star mismatch).

Checks expected:
- Title ✅ Add owner/repo to Category? (this title is test, should be flagged)
- Bilingual ✅ (both READMEs touched)
- Star 0 vs live? test repo 404 -> should be flagged
- dsh-plugin ❌

No need to merge, will close after test.

## Summary by Sourcery

Chores:
- Add the curator test repository to the plugins catalog with a placeholder description and zero stars.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This test-only PR adds a deliberately invalid plugin entry to exercise curator automation.
- Adds `test/test-plugin-demo` to the README plugin catalog.
- Intentionally uses a nonexistent repository and zero-star metadata to trigger validation checks.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No actionable review finding remains because the invalid entry is explicitly intentional and this test PR is designated for closure rather than merge.

The sole change is a documented test fixture intended to trigger curator validation, and its otherwise-invalid catalog data is fully acknowledged in the PR description.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds one intentionally invalid catalog row for curator bot testing; the PR explicitly states it should not be merged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: curator PR for auto checks (do not..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/aa27b476633c3785431b28dc0327600002252d21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57512523)</sub>

<!-- /greptile_comment -->