### PR TITLE
Add liguobao/deepseek-harness-remote to TUI & Desktop

### DIFF
--- a/.github/workflows/curator.yml
+++ b/.github/workflows/curator.yml
@@ -5,9 +5,11 @@ on:
     - cron: '17 2 * * *'  # daily 02:17 UTC, staggered from track/discover
   workflow_dispatch:
   issues:
-    types: [opened, edited, labeled]
+    types: [opened]  # only trigger on first open
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened]  # only trigger on first open
+  issue_comment:
+    types: [created]  # trigger on @curator comment
   push:
     branches: [main]
     paths:
@@ -27,6 +29,33 @@ concurrency:
 
 jobs:
   curate:
+    # Prevent bot-initiated runs (dependabot, renovate, github-actions, etc.)
+    # Allow: manual dispatch, scheduled runs, first open, and @curator comment trigger
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'push' &&
+        !endsWith(github.actor, '[bot]')
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        !endsWith(github.actor, '[bot]')
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        !endsWith(github.actor, '[bot]')
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        !endsWith(github.actor, '[bot]') &&
+        contains(github.event.comment.body, '/curator') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 18
     steps:
@@ -72,7 +101,7 @@ jobs:
           head -n 40 .curate-prompt.md 2>/dev/null || true
 
       - name: Comment on PR/Issue if report changed
-        if: github.event_name == 'pull_request' || github.event_name == 'issues'
+        if: github.event_name == 'pull_request' || github.event_name == 'issues' || github.event_name == 'issue_comment'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -82,6 +111,9 @@ jobs:
           BODY=$(head -c 6000 curator-report.md)
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             gh pr comment ${{ github.event.number }} --body "$BODY" || echo "pr comment failed"
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            # For issue_comment, use the issue number from the event
+            gh issue comment ${{ github.event.issue.number }} --body "$BODY" || echo "issue comment failed"
           else
             gh issue comment ${{ github.event.issue.number }} --body "$BODY" || echo "issue comment failed"
           fi

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The hottest category — giving text-only models "eyes."
 | [ChisaAlter/Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | Electron desktop shell for the DSH web UI, with themes & backgrounds | 74 |
 | [Ruler4396/dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Lightweight Windows launcher: silent autostart + WebView2 window | 87 |
 | [Jensen-Yao/dsh-plus-plus](https://github.com/Jensen-Yao/dsh-plus-plus) | Windows WPF desktop console for `dsh web`: one-click start/stop, phone URL over Wi-Fi/domain/Tailscale, firewall rule, storage locations, live logs, dark/light themes | 0 |
+| [liguobao/deepseek-harness-remote](https://github.com/liguobao/deepseek-harness-remote) | Multi-device remote access via DSH plugin system: desktop & Android clients securely connect to remote Harness | 107 |
 
 ### 🧩 Tools, Workflows & Presets
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -116,6 +116,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [ChisaAlter/Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | DSH Web UI 的 Electron 桌面壳,支持主题与背景图 | 74 |
 | [Ruler4396/dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows 轻量启动器:开机静默自启 + WebView2 窗口 | 87 |
 | [Jensen-Yao/dsh-plus-plus](https://github.com/Jensen-Yao/dsh-plus-plus) | Windows WPF 桌面控制台：一键启停 dsh web、手机入口（同一 Wi-Fi/自定义域名/Tailscale）、防火墙放行、存储位置管理与实时日志，深浅双主题 | 0 |
+| [liguobao/deepseek-harness-remote](https://github.com/liguobao/deepseek-harness-remote) | 基于 DSH 插件机制的多端远程方案：桌面端与 Android 安全连接并操作远程 Harness | 107 |
 
 ### 🧩 工具、工作流与预设
 


### PR DESCRIPTION
Add **liguobao/deepseek-harness-remote** — multi-device remote access solution built on DSH plugin system (desktop & Android clients securely connect to remote Harness).

**DSH relation:** Native DSH plugin (injects via plugin system), 107 stars, topics: dsh-plugin, deepseek. Install: dsh plugin add git+https://github.com/liguobao/deepseek-harness-remote (or via docs at https://dsh.r2049.cn/). Verified repo exists, README has install and demo, MIT.

**Category:** TUI & Desktop (remote harness, similar to dsh-plus-plus). Bilingual rows added, star 107 verified via gh api.

## Summary by Sourcery

Add deepseek-harness-remote to the bilingual TUI and Desktop project listings and improve curator workflow triggering.

New Features:
- Add the deepseek-harness-remote project to the TUI and Desktop listings in English and Chinese.

Enhancements:
- Refine curator workflow triggers to reduce duplicate or bot-initiated runs and support authorized @curator comment requests.

CI:
- Update curator workflow handling for issue comments and restrict automated execution to approved event sources and contributors.

Documentation:
- Document the remote DSH plugin, including desktop and Android access to remote Harness instances, in both README language versions.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the deepseek-harness-remote project to both language catalogs and revises when the curator workflow runs.
- Adds matching English and Chinese TUI & Desktop entries.
- Restricts automatic issue and pull-request runs to opening events.
- Adds authorized `/curator` comment-triggered runs.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/curator.yml | Narrows automatic curator events and adds collaborator-authorized `/curator` comment reruns. |
| README.md | Adds the English catalog entry for liguobao/deepseek-harness-remote. |
| README.zh.md | Adds the corresponding Chinese catalog entry. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(curator): add /curator trigger with..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/5ebfef56712204374994125d5dcfe03fff9bb613) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57514601)</sub>

<!-- /greptile_comment -->