### PR TITLE
feat: add dsh-context plugin (context insight & management)

### DIFF
--- a/.github/workflows/curator.yml
+++ b/.github/workflows/curator.yml
@@ -5,9 +5,11 @@ on:
     - cron: '17 2 * * *'  # daily 02:17 UTC, staggered from track/discover
   workflow_dispatch:
   issues:
-    types: [opened, edited, labeled]
+    types: [opened]  # only trigger on first open
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened]  # only trigger on first open
+  issue_comment:
+    types: [created]  # trigger on @curator comment
   push:
     branches: [main]
     paths:
@@ -27,6 +29,33 @@ concurrency:
 
 jobs:
   curate:
+    # Prevent bot-initiated runs (dependabot, renovate, github-actions, etc.)
+    # Allow: manual dispatch, scheduled runs, first open, and @curator comment trigger
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'push' &&
+        !endsWith(github.actor, '[bot]')
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        !endsWith(github.actor, '[bot]')
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        !endsWith(github.actor, '[bot]')
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        !endsWith(github.actor, '[bot]') &&
+        contains(github.event.comment.body, '/curator') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 18
     steps:
@@ -72,7 +101,7 @@ jobs:
           head -n 40 .curate-prompt.md 2>/dev/null || true
 
       - name: Comment on PR/Issue if report changed
-        if: github.event_name == 'pull_request' || github.event_name == 'issues'
+        if: github.event_name == 'pull_request' || github.event_name == 'issues' || github.event_name == 'issue_comment'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -82,6 +111,9 @@ jobs:
           BODY=$(head -c 6000 curator-report.md)
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             gh pr comment ${{ github.event.number }} --body "$BODY" || echo "pr comment failed"
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            # For issue_comment, use the issue number from the event
+            gh issue comment ${{ github.event.issue.number }} --body "$BODY" || echo "issue comment failed"
           else
             gh issue comment ${{ github.event.issue.number }} --body "$BODY" || echo "issue comment failed"
           fi

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The hottest category — giving text-only models "eyes."
 | [ChisaAlter/Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | Electron desktop shell for the DSH web UI, with themes & backgrounds | 74 |
 | [Ruler4396/dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Lightweight Windows launcher: silent autostart + WebView2 window | 87 |
 | [Jensen-Yao/dsh-plus-plus](https://github.com/Jensen-Yao/dsh-plus-plus) | Windows WPF desktop console for `dsh web`: one-click start/stop, phone URL over Wi-Fi/domain/Tailscale, firewall rule, storage locations, live logs, dark/light themes | 0 |
+| [liguobao/deepseek-harness-remote](https://github.com/liguobao/deepseek-harness-remote) | Multi-device remote access via DSH plugin system: desktop & Android clients securely connect to remote Harness | 107 |
 
 ### 🧩 Tools, Workflows & Presets
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) | Context insight & management: context dashboard/browser, statistics, composition breakdown, evolution details | 1104 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -116,6 +116,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [ChisaAlter/Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | DSH Web UI 的 Electron 桌面壳,支持主题与背景图 | 74 |
 | [Ruler4396/dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows 轻量启动器:开机静默自启 + WebView2 窗口 | 87 |
 | [Jensen-Yao/dsh-plus-plus](https://github.com/Jensen-Yao/dsh-plus-plus) | Windows WPF 桌面控制台：一键启停 dsh web、手机入口（同一 Wi-Fi/自定义域名/Tailscale）、防火墙放行、存储位置管理与实时日志，深浅双主题 | 0 |
+| [liguobao/deepseek-harness-remote](https://github.com/liguobao/deepseek-harness-remote) | 基于 DSH 插件机制的多端远程方案：桌面端与 Android 安全连接并操作远程 Harness | 107 |
 
 ### 🧩 工具、工作流与预设
 


### PR DESCRIPTION
添加 dsh-context 插件到 Tools, Workflows & Presets 分类。

**插件信息：**
- 仓库：[bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context)
- Stars：1104
- 功能：一站式上下文可视化插件，Context 面板及浏览器与 Context 命令，透视上下文组成、演进、压缩、剪枝等事件与动作

**测试 /curator 触发功能**

## Summary by Sourcery

Add the dsh-context plugin to the project catalog and improve curator workflow triggering and comment handling.

New Features:
- Add dsh-context to the Tools, Workflows & Presets catalog for context visualization and management.

CI:
- Restrict curator workflow triggers to initial issue and pull request creation, while adding authorized /curator comment support and filtering bot-initiated runs.

Documentation:
- Update English and Chinese README catalogs with dsh-context and the newly listed deepseek-harness-remote project.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds dsh-context and deepseek-harness-remote catalog entries and introduces trusted-comment activation for the curator workflow while narrowing automatic event triggers.
- Adds `/curator` handling for comments from repository-associated users.
- Restricts issue and pull-request automatic curation to initial opening.
- Adds project rows to the English and Chinese catalogs, although dsh-context is missing from the Chinese catalog.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The pull request should not merge until comment-triggered PR curation uses the correct PR context and the dsh-context entry is added to the Chinese catalog.

The new comment trigger misclassifies pull requests and checks out default-branch content, while the catalog update also violates the repository’s required bilingual synchronization.

**Files Needing Attention:** .github/workflows/curator.yml, README.md, README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/curator.yml | Adds a guarded issue-comment trigger, but does not adapt PR identification or checkout behavior to the issue_comment payload. |
| README.md | Adds two catalog entries, including dsh-context without the required matching Chinese entry. |
| README.zh.md | Adds the deepseek-harness-remote translation but omits the dsh-context entry present in README.md. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Trusted user posts /curator] --> B[issue_comment event]
  B --> C{Comment guard passes}
  C --> D[Checkout default branch]
  C --> E[GH_PR reads missing event.number]
  E --> F[Curator selects issue path]
  D --> G[Report does not inspect PR head]
  F --> H[Issue-style report posted to PR]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/curator.yml:11-12
**PR context is lost**

When a trusted collaborator posts `/curator` on a pull request, the `issue_comment` payload leaves `github.event.number` empty while the unqualified checkout uses the default branch, so the curator selects its issue path and analyzes default-branch content instead of the pull request changes, producing an issue-style report without PR-specific checks.

### Issue 2
README.md:144
**Bilingual catalog is incomplete**

The new `dsh-context` row has no corresponding entry in the Tools, Workflows & Presets section of `README.zh.md`, so Chinese-language readers cannot discover the plugin and the catalog violates the repository's requirement to update both README variants together.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add dsh-context plugin (context in..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/12c9684acbd00ff1e5b5cf0ed3de5c26aa538fb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57526272)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->