### PR TITLE
fix(curator): support /curator issue_comment trigger with PR context

### DIFF
--- a/.github/workflows/curator.yml
+++ b/.github/workflows/curator.yml
@@ -8,6 +8,8 @@ on:
     types: [opened, edited, labeled]
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  issue_comment:
+    types: [created]
   push:
     branches: [main]
     paths:
@@ -22,15 +24,50 @@ permissions:
   id-token: write
 
 concurrency:
-  group: curator-${{ github.event_name }}-${{ github.event.number || github.run_id }}
+  group: curator-${{ github.event_name }}-${{ github.event.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
   curate:
+    # Guard: schedule/dispatch/push/issues/pull_request run unconditionally (except bots);
+    # issue_comment only runs when comment contains /curator and actor is OWNER/MEMBER/COLLABORATOR
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'push' &&
+        !endsWith(github.actor, '[bot]')
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        !endsWith(github.actor, '[bot]')
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        !endsWith(github.actor, '[bot]')
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        !endsWith(github.actor, '[bot]') &&
+        contains(github.event.comment.body, '/curator') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 18
     steps:
-      - name: Checkout
+      - name: Checkout (PR comment)
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.issue.number }}/head
+
+      - name: Checkout (default)
+        if: github.event_name != 'issue_comment' || !github.event.issue.pull_request
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -57,14 +94,27 @@ jobs:
       - name: Run curator (free-model traversal)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_PR: ${{ github.event.number }}
-          GH_ISSUE: ${{ github.event.issue.number }}
+          GH_PR: ${{ github.event.number || '' }}
+          GH_ISSUE: ${{ github.event.issue.number || '' }}
+          GH_COMMENT_PR: ${{ github.event.issue.number || '' }}
+          GH_COMMENT_IS_PR: ${{ github.event.issue.pull_request && 'true' || 'false' }}
+          GH_COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -e
-          echo "Event: ${{ github.event_name }} PR=${{ github.event.number }} Issue=${{ github.event.issue.number }}"
+          echo "Event: ${{ github.event_name }} PR=${{ github.event.number }} Issue=${{ github.event.issue.number }} CommentIsPR=${{ github.event.issue.pull_request && 'true' || 'false' }}"
+          # Resolve effective PR/ISSUE for issue_comment on PR:
+          # - issue_comment on PR: GH_PR empty, GH_ISSUE == PR number, GH_COMMENT_IS_PR == true → treat as PR
+          # - issue_comment on Issue: GH_COMMENT_IS_PR == false → treat as Issue
+          # Export resolved vars for curate.mjs (it also has internal fallback)
+          if [ "${{ github.event_name }}" = "issue_comment" ] && [ "${{ github.event.issue.pull_request && 'true' || 'false' }}" = "true" ]; then
+            export GH_PR="${{ github.event.issue.number }}"
+            export GH_ISSUE=""
+            echo "Resolved issue_comment on PR → GH_PR=$GH_PR"
+          fi
           node scripts/curate.mjs
           echo "--- curator-report preview ---"
           head -n 150 curator-report.md || true
@@ -72,7 +122,7 @@ jobs:
           head -n 40 .curate-prompt.md 2>/dev/null || true
 
       - name: Comment on PR/Issue if report changed
-        if: github.event_name == 'pull_request' || github.event_name == 'issues'
+        if: github.event_name == 'pull_request' || github.event_name == 'issues' || github.event_name == 'issue_comment'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -82,6 +132,8 @@ jobs:
           BODY=$(head -c 6000 curator-report.md)
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             gh pr comment ${{ github.event.number }} --body "$BODY" || echo "pr comment failed"
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            gh issue comment ${{ github.event.issue.number }} --body "$BODY" || echo "issue comment failed"
           else
             gh issue comment ${{ github.event.issue.number }} --body "$BODY" || echo "issue comment failed"
           fi

--- a/scripts/curate.mjs
+++ b/scripts/curate.mjs
@@ -111,7 +111,7 @@ async function runPreliminaryChecks(pr, issue) {
         out.push(`- Title: "${j.title}" ${titleOk ? '✅ matches Add owner/repo to Category' : '❌ should be Add owner/repo to Category'}`);
         const files = (j.files || []).map(f => f.path).join(', ');
         out.push(`- Files: ${files || '(none)'} ${files.includes('README.md') && files.includes('README.zh.md') ? '✅ bilingual' : '❌ missing README.md or README.zh.md'}`);
-        // Extract owner/repo from diff via title or body
+        // Extract owner/repo from diff via title or body (+ /curator comment link as fallback)
         // Robust owner/repo extraction: prefer https://github.com/owner/repo, fallback to generic but ignore github.com
         let repo = null;
         const ghMatch = (j.title + ' ' + (j.body || '')).match(/https?:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/i);
@@ -119,6 +119,11 @@ async function runPreliminaryChecks(pr, issue) {
         else {
           const generic = (j.title + ' ' + (j.body || '')).match(/(?<![a-zA-Z0-9_.-])([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)(?![a-zA-Z0-9_.-])/);
           if (generic && generic[1] !== 'github.com/thedeveloper256' && !generic[1].startsWith('github.com/')) repo = generic[1];
+          // Also try /curator comment body (e.g. "/curator https://github.com/owner/repo")
+          if (!repo && process.env.GH_COMMENT_BODY) {
+            const cMatch = process.env.GH_COMMENT_BODY.match(/https?:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/i);
+            if (cMatch) repo = cMatch[1].replace(/\.git$|\/$/, '');
+          }
           // Also try files diff: look for owner/repo in body via gh pr diff? fallback to files path check
           if (!repo && j.files) {
             const fromFiles = JSON.stringify(j.files).match(/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/);
@@ -374,8 +379,44 @@ ${issue ? `- Issue #${issue} detected. Suggest labels: plugin suggestion / fix /
 
 async function main() {
   console.log(`[curate] Starting at ${new Date().toISOString()}`);
-  const pr = process.env.GH_PR || process.env.PR_NUMBER || '';
-  const issue = process.env.GH_ISSUE || process.env.ISSUE_NUMBER || '';
+  let pr = process.env.GH_PR || process.env.PR_NUMBER || '';
+  let issue = process.env.GH_ISSUE || process.env.ISSUE_NUMBER || '';
+  const eventName = process.env.GITHUB_EVENT_NAME || process.env.GH_EVENT || '';
+  const commentBody = process.env.GH_COMMENT_BODY || '';
+  const commentIsPr = process.env.GH_COMMENT_IS_PR === 'true';
+  const commentPr = process.env.GH_COMMENT_PR || '';
+
+  // Fix for issue_comment on PR: workflow sets GH_PR empty + GH_ISSUE==PR number.
+  // Detect and normalize so PRs triggered via /curator are treated as PR, not Issue.
+  // Also fallback to local gh detection if envs are ambiguous.
+  if (eventName === 'issue_comment' && commentIsPr && !pr && issue && commentPr === issue) {
+    console.log(`[curate] Normalizing issue_comment on PR: issue #${issue} → pr #${issue}`);
+    pr = issue;
+    issue = '';
+  } else if (!pr && issue && eventName === 'issue_comment') {
+    // Fallback: probe whether GH_ISSUE is actually a PR via gh pr view
+    try {
+      const probe = await new Promise(res => {
+        const c = spawn('gh', ['pr', 'view', String(issue), '--json', 'number', '--jq', '.number'], { stdio: ['pipe','pipe','pipe'], shell: false });
+        let o='', e='';
+        c.stdout.on('data', d=>o+=d); c.stderr.on('data', d=>e+=d);
+        c.on('close', code=>res({code,out:o,err:e})); c.on('error', err=>res({code:1,out:'',err:err.message}));
+      });
+      if (probe.code === 0 && probe.out.trim()) {
+        console.log(`[curate] Probe: #${issue} is a PR → treating as PR`);
+        pr = issue;
+        issue = '';
+      }
+    } catch {}
+  }
+  if (commentBody && commentBody.includes('/curator')) {
+    console.log(`[curate] Triggered via /curator comment: "${commentBody.slice(0,120)}"`);
+    // If comment contains https://github.com/owner/repo, append to pr body context for repo extraction
+    const urlMatch = commentBody.match(/https?:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/i);
+    if (urlMatch && pr) {
+      console.log(`[curate] Comment contains repo link ${urlMatch[1]} — will be considered by curator agent`);
+    }
+  }
   const preChecks = await runPreliminaryChecks(pr, issue);
   console.log(`[curate] Preliminary checks:\n${preChecks}\n---`);
   try { await runAutoLabel(pr, issue, preChecks); } catch (e) { console.warn(`[curate] autoLabel failed: ${e.message}`); }


### PR DESCRIPTION
修复 /curator 在 PR 中不起作用的问题（用户反馈：/curator + repo 链接无响应）。

根因：main 的 curator.yml 仅监听 issues/pull_request/push，无 issue_comment，评论触发永远不会执行。验证最近 100 次 workflow 无 issue_comment run。

本次修复：
- .github/workflows/curator.yml 新增 issue_comment: created
- concurrency 加入 issue.number fallback
- jobs.curate.if 加守卫：仅当 contains(comment.body, '/curator') 且 author_association in OWNER/MEMBER/COLLABORATOR 且非 bot 才执行
- Checkout 拆分：issue_comment 且为 PR 时检出 refs/pull/N/head
- Run curator env 新增 GH_COMMENT_BODY/GH_COMMENT_IS_PR/GITHUB_EVENT_NAME，并在 bash 中矫正 GH_PR
- runPreliminaryChecks 新增对 GH_COMMENT_BODY 中 https://github.com/owner/repo 的提取
- Comment step 支持 issue_comment

验证计划：
1. 本 PR 打开后自动触发一次 curator
2. 评论 /curator 应再次触发并回贴 report

## Summary by Sourcery

Enable authorized `/curator` issue comments to trigger Curator with the correct pull request or issue context and report results back to GitHub.

New Features:
- Enable Curator to run from authorized `/curator` comments on issues and pull requests.
- Support repository links in `/curator` comments as curator context.

Bug Fixes:
- Fix Curator comment triggers on pull requests by correctly identifying and processing the pull request context.
- Post curator reports for `issue_comment`-triggered runs.

Enhancements:
- Add event-specific concurrency, checkout, and execution handling for comment-triggered workflows.
- Restrict comment-triggered runs to non-bot collaborators, members, and owners.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds `/curator` support for issue and pull-request comments, normalizes comment event context, extracts repository links from command comments, and posts generated reports back to the originating conversation.

- Adds the `issue_comment` trigger, authorization guard, concurrency key, and event-specific checkout.
- Passes comment metadata into the curator script and normalizes pull-request versus issue identifiers.
- Adds comment-body repository extraction and `issue_comment` report posting.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

This PR is not safe to merge until the untrusted PR-head execution path is removed and comment repository URLs are normalized correctly.

A maintainer’s `/curator` comment can execute pull-request-controlled JavaScript with write-capable credentials, and ordinary punctuated repository links can be converted into invalid API targets.

**Files Needing Attention:** .github/workflows/curator.yml, scripts/curate.mjs
</details>


<details open><summary><h3>Security Review</h3></summary>

The new pull-request comment path executes code from the pull-request head while exposing write-capable repository credentials and external API secrets. A trusted collaborator invoking `/curator` on an untrusted pull request therefore creates a credential-exfiltration and unauthorized-write path. **How this was verified:** The workflow directly connects the PR-head checkout to `node scripts/curate.mjs` with write permissions and secrets, without restoring trusted code.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/curator.yml | Adds the comment trigger and PR-context handling, but executes PR-head code with write permissions and external API credentials. |
| scripts/curate.mjs | Normalizes issue-comment PR context and adds repository extraction from comments, but mishandles common trailing punctuation in repository links. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Author as PR author
  participant Maintainer
  participant Actions as GitHub Actions
  participant Head as PR head checkout
  participant Script as scripts/curate.mjs
  participant GitHub as GitHub API

  Author->>Head: Submit PR containing changed code
  Maintainer->>Actions: Comment /curator
  Actions->>Head: Checkout refs/pull/N/head
  Actions->>Script: Execute checked-out script with tokens and API keys
  Script->>GitHub: Read or mutate repository state
  Script->>GitHub: Post curator report
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/curator.yml:67
**PR head exposes secrets**

When a repository owner, member, or collaborator comments `/curator` on a malicious pull request, the workflow checks out that PR head and executes its `scripts/curate.mjs` with write-capable `GITHUB_TOKEN` permissions and external API keys, allowing the PR author to exfiltrate credentials or perform unauthorized repository changes. **How this was verified:** The PR-head checkout flows directly into `node scripts/curate.mjs` with credentials, without restoring trusted code.

### Issue 2
scripts/curate.mjs:124-125
**URLs retain terminal punctuation**

When a `/curator` repository URL ends with prose punctuation, such as `https://github.com/owner/repo.`, the new fallback captures `owner/repo.` and only strips `.git` or `/`, causing the subsequent GitHub API lookup to target a nonexistent repository and report failed preliminary checks.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(curator): support /curator issue\_com..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/50db0e298636ffc47dce1d531c8d92265c38b064) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57782447)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->