### PR TITLE
Add PerryLink/dsh-draw to Vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The hottest category — giving text-only models "eyes."
 | [Anionex/agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) | Vision toolkit & skills for text-only LLMs: multi-image, Q&A, frontend UI restoration, GUI automation | 871 |
 | [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | Built-in free vision chain (no key) + pixel-level vision tools; one-command install, no Python | 94 |
 | [QwenLM/Qwen-MM-Plugins](https://github.com/QwenLM/Qwen-MM-Plugins) | Make any agent harness multimodal-native (cross-harness) | 2549 |
+| [PerryLink/dsh-draw](https://github.com/PerryLink/dsh-draw) | Unified static-image generation routing for DeepSeek Harness: one image_generate tool across OpenAI Images, Zhipu CogView, and compatible endpoints, with health-aware fallback and durable results. | 3 |
 
 ### 🌐 Web & Browser
 
@@ -140,6 +141,7 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -67,6 +67,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [Anionex/agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) | 纯文本模型的视觉工具箱与技能:多图理解、图片问答、前端 UI 还原、GUI 自动化 | 871 |
 | [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 内置免费视觉链(无需 key)+ 像素级视觉工具,一键安装,无需 Python | 94 |
 | [QwenLM/Qwen-MM-Plugins](https://github.com/QwenLM/Qwen-MM-Plugins) | 让任意 agent harness 具备多模态能力(跨 harness) | 2549 |
+| [PerryLink/dsh-draw](https://github.com/PerryLink/dsh-draw) | DeepSeek Harness 的统一静态图像生成路由：一个 image_generate 工具横跨 OpenAI Images、智谱 CogView 与兼容端点，健康感知回退、结果持久化。 | 3 |
 
 ### 🌐 Web 与浏览器
 
@@ -141,6 +142,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Unified static-image generation routing for DeepSeek Harness: one image_generate tool across OpenAI Images, Zhipu CogView, and compatible endpoints, with health-aware fallback and durable results.
- **Install**: `dsh plugin --profile web add dsh-draw` (npm: dsh-draw@0.2.1)
- **License**: Apache-2.0 - **Stars**: 3 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Vision is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-draw` in both READMEs).

## Summary by Sourcery

Expand the Vision catalog with dsh-draw and synchronize the translated plugin listings with dsh-auto-review.

New Features:
- Add PerryLink/dsh-draw to the Vision plugin listings in the English and Chinese READMEs.

Documentation:
- Update the English and Chinese plugin catalogs with descriptions and repository links for dsh-draw.

Chores:
- Add the dsh-auto-review plugin to the Other listings in both README translations.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PerryLink/dsh-draw to the Vision tables in both English and Chinese documentation.
- Documents dsh-draw as a unified static-image generation router with three stars.
- Also introduces an unrelated PerryLink/dsh-auto-review entry in both README variants.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The unrelated dsh-auto-review additions should be removed or explicitly included in the PR scope before merging.

Both README variants publish a second project that is not mentioned in the title, description, or stated purpose of the PR.

**Files Needing Attention:** README.md, README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds the intended dsh-draw Vision entry but also adds an unrelated dsh-auto-review catalog entry. |
| README.zh.md | Mirrors both the intended dsh-draw entry and the unrelated dsh-auto-review entry in Chinese. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:144
**Unrelated project enters catalog**

When this documentation is published, the added row also lists `PerryLink/dsh-auto-review`, causing an unrelated project to enter the catalog even though this PR is scoped to adding `PerryLink/dsh-draw`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-draw to Vision"](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/678265e39eacce8b5e8f7120abcf25bfd1ee1e10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331692)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->