### PR TITLE
Add PerryLink/dsh-library to Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The hottest category — giving text-only models "eyes."
 | [tinqiao-oss/engramory](https://github.com/tinqiao-oss/engramory) | Portable memory protocol for AI agents: load as standing rules, curation discipline + reference spec | 152 |
 | [text2future/flowix](https://github.com/text2future/flowix) | Notes for you, memory for your agents | 280 |
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | A unified agent memory workspace for human and agent | 131 |
+| [PerryLink/dsh-library](https://github.com/PerryLink/dsh-library) | Turns local markdown and text documents into a queryable knowledge base with hybrid semantic and keyword search, citation verification, and source injection. | 4 |
 
 ### 🎨 Web UI, Skins & Desktop Pets
 
@@ -140,6 +141,7 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -86,6 +86,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [tinqiao-oss/engramory](https://github.com/tinqiao-oss/engramory) | 可移植的 agent 记忆协议:常驻规则加载、策展纪律 + 参考规范 | 152 |
 | [text2future/flowix](https://github.com/text2future/flowix) | 给你笔记、给 agent 记忆 | 280 |
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | 人与 agent 的统一记忆工作区 | 131 |
+| [PerryLink/dsh-library](https://github.com/PerryLink/dsh-library) | 将本地 Markdown 与文本文档转为可检索的知识库，支持语义与关键词混合搜索、引用校验与来源注入。 | 4 |
 
 ### 🎨 Web UI、皮肤与桌面宠物
 
@@ -141,6 +142,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Turns local markdown and text documents into a queryable knowledge base with hybrid semantic and keyword search, citation verification, and source injection.
- **Install**: `dsh plugin --profile web add dsh-library` (npm: dsh-library@0.2.0)
- **License**: Apache-2.0 - **Stars**: 4 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Memory is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-library` in both READMEs).

## Summary by Sourcery

Expand the plugin catalog with PerryLink’s memory and automated review plugins across both README translations.

New Features:
- Add PerryLink/dsh-library to the Memory plugin directory in the English and Chinese READMEs.

Documentation:
- Update both README language versions with the dsh-library listing and its knowledge-base capabilities.
- Add the PerryLink/dsh-auto-review plugin listing to the relevant English and Chinese README sections.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PerryLink/dsh-library to the English and Chinese Memory sections, but also includes an unrelated project not covered by the PR description.
- Adds dsh-library descriptions and star counts to both localized READMEs.
- Also adds dsh-auto-review to both Tools, Workflows & Presets tables.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The unrelated dsh-auto-review additions should be removed or explicitly included and justified before merging.

Both localized READMEs contain an additional project entry that is independent of the dsh-library change described and justified by the pull request.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds the intended dsh-library row, plus an unrelated dsh-auto-review row that is outside the stated PR scope. |
| README.zh.md | Mirrors both English additions, including the unrelated dsh-auto-review entry. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:144
**Unrelated project added**

This PR is scoped to adding `dsh-library`, but this row also publishes the separate `dsh-auto-review` project in both localized lists, causing an unrelated project to be merged without the review context or justification supplied for the intended entry.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-library to Memor..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/e6070c9580d6cc533e3b1d6f1cf78b6a3a0f0f46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331719)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->