### PR TITLE
Add PerryLink/dsh-memento to Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The hottest category — giving text-only models "eyes."
 | [tinqiao-oss/engramory](https://github.com/tinqiao-oss/engramory) | Portable memory protocol for AI agents: load as standing rules, curation discipline + reference spec | 152 |
 | [text2future/flowix](https://github.com/text2future/flowix) | Notes for you, memory for your agents | 280 |
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | A unified agent memory workspace for human and agent | 131 |
+| [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | Bounded, layered, approval-gated, auditable cross-session memory: a typed `ctx.memory` seam with a zero-dependency SQLite provider, a `memory` tool, and frozen snapshot injection, plus the dsh-memory-protocol v1 rehearsal with an adapter registry and a distributable conformance suite. | 74 |
 
 ### 🎨 Web UI, Skins & Desktop Pets
 
@@ -140,6 +141,7 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -86,6 +86,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [tinqiao-oss/engramory](https://github.com/tinqiao-oss/engramory) | 可移植的 agent 记忆协议:常驻规则加载、策展纪律 + 参考规范 | 152 |
 | [text2future/flowix](https://github.com/text2future/flowix) | 给你笔记、给 agent 记忆 | 280 |
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | 人与 agent 的统一记忆工作区 | 131 |
+| [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | 有界、分层、带审批门、可审计的跨会话记忆：`ctx.memory` 服务 + 零依赖 SQLite 存储 + `memory` 工具与冻结快照注入，并预演 dsh-memory-protocol v1——适配器注册表与可分发的一致性套件。 | 74 |
 
 ### 🎨 Web UI、皮肤与桌面宠物
 
@@ -141,6 +142,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Bounded, layered, approval-gated, auditable cross-session memory: a typed `ctx.memory` seam with a zero-dependency SQLite provider, a `memory` tool, and frozen snapshot injection, plus the dsh-memory-protocol v1 rehearsal with an adapter registry and a distributable conformance suite.
- **Install**: `dsh plugin --profile web add dsh-memento` (npm: dsh-memento@0.5.0)
- **License**: Apache-2.0 - **Stars**: 74 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Memory is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-memento` in both READMEs).

## Summary by Sourcery

Update the English and Chinese project catalogs with newly listed DSH plugins.

New Features:
- Add PerryLink/dsh-memento to the Memory listings in the English and Chinese READMEs.
- Add PerryLink/dsh-auto-review to the relevant tool listings in the English and Chinese READMEs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation PR updates both localized catalogs with PerryLink project listings.
- Adds dsh-memento to the Memory section in English and Chinese.
- Also adds dsh-auto-review to the Tools, Workflows & Presets section, despite that addition not being described in the PR.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after the non-blocking scope issue around the undeclared dsh-auto-review listing is resolved.

The requested dsh-memento documentation is consistently added in both languages, but both files also introduce a second project that is not covered by the PR description or its stated validation.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds the requested dsh-memento entry and an additional, undeclared dsh-auto-review entry. |
| README.zh.md | Mirrors both new English catalog entries in Chinese, including the unrelated dsh-auto-review addition. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:144
**Undeclared catalog addition**

This line adds `dsh-auto-review` in both language variants even though the PR title, description, rationale, and validation cover only `dsh-memento`, allowing a second project to enter the curated catalog without project-specific review context.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-memento to Memor..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/204316ffdbaac4e1fa78d65fb45ae6ea798d953c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331728)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->