### PR TITLE
Add PerryLink/dsh-output-styles to Web UI, Skins & Desktop Pets

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The hottest category — giving text-only models "eyes."
 | [zizaiwo/dsh_plugins](https://github.com/zizaiwo/dsh_plugins) | Sidebar session categories for dsh Web UI: zero-config takeover of official workspace browser, organize sessions by custom folders (drag & drop, in-category creation, per-workspace isolation) | 0 |
 | [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) | Quick-prompts bar above composer: per-category snippet chips, orange {{placeholder}} highlighting, two-column management, per-session category memory | 0 |
 | [Moonshile/moonshile-dsh-plugins](https://github.com/Moonshile/moonshile-dsh-plugins) | Re-sorts sidebar workspaces by last activity once per day; stable order within the day | 0 |
+| [PerryLink/dsh-output-styles](https://github.com/PerryLink/dsh-output-styles) | Runtime-switchable model output styles with Claude Code outputStyles parity, plus the output.render.* presentation protocol: a /style command, per-session persistence, systemPrompt injection, six built-in styles, a web picker, and a renderer registry with per-session/per-tool rules and /export. | 4 |
 ### 🖥️ TUI & Desktop
 
 | Project | Description | ⭐ |
@@ -140,6 +141,7 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -103,6 +103,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [zizaiwo/dsh_plugins](https://github.com/zizaiwo/dsh_plugins) | dsh 侧边栏会话分类插件：零配置接管官方工作区浏览器，按自定义分类文件夹管理会话（拖拽归类/分类内建会话/每工作区独立） | 0 |
 | [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) | 输入框上方的快捷指令胶囊栏：按分类存常用 prompt，橙色高亮占位符，两栏管理，分类记忆按会话独立持久化 | 0 |
 | [Moonshile/moonshile-dsh-plugins](https://github.com/Moonshile/moonshile-dsh-plugins) | 侧边栏工作区每日按最近活动排序一次，当天顺序稳定 | 0 |
+| [PerryLink/dsh-output-styles](https://github.com/PerryLink/dsh-output-styles) | 运行时切换模型输出风格（对标 Claude Code outputStyles），另加 output.render.* 呈现协议：/style 命令、按会话持久化、systemPrompt 注入、六个内置风格、Web 选择器，以及带按会话/按工具规则与 /export 的渲染器注册表。 | 4 |
 
 ### 🖥️ TUI 与桌面端
 
@@ -141,6 +142,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Runtime-switchable model output styles with Claude Code outputStyles parity, plus the output.render.* presentation protocol: a /style command, per-session persistence, systemPrompt injection, six built-in styles, a web picker, and a renderer registry with per-session/per-tool rules and /export.
- **Install**: `dsh plugin --profile web add dsh-output-styles` (npm: dsh-output-styles@0.6.1)
- **License**: Apache-2.0 - **Stars**: 4 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Web UI, Skins & Desktop Pets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-output-styles` in both READMEs).

## Summary by Sourcery

Update the English and Chinese plugin directories with the newly listed output-styles and auto-review projects.

Enhancements:
- Add the PerryLink/dsh-output-styles plugin to the Web UI, Skins & Desktop Pets listings in the English and Chinese READMEs.

Chores:
- Add the PerryLink/dsh-auto-review plugin to the TUI & Desktop listings in the English and Chinese READMEs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the PerryLink/dsh-output-styles project to the English and Chinese Web UI catalog. It also unintentionally adds a separate dsh-auto-review project outside the stated scope.
- Adds matching dsh-output-styles entries to README.md and README.zh.md.
- Adds an unrelated dsh-auto-review entry to both plugin catalogs.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The unrelated dsh-auto-review catalog entry should be removed before merging this otherwise straightforward documentation update.

Both READMEs publish a second project that is not identified by the PR title or description and therefore bypasses an independently scoped review of that listing.

**Files Needing Attention:** README.md, README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds the requested output-styles listing but also introduces an unrelated auto-review listing. |
| README.zh.md | Mirrors both the requested listing and the unrelated addition in Chinese. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:144
**Unrelated catalog entry added**

When this PR is merged as the advertised `dsh-output-styles` submission, it also publishes `dsh-auto-review` in both language variants, adding a separate project and unreviewed metadata outside the stated scope.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-output-styles to..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/afdb912dc0fd2b1bb14532b3a64e605f1c659983) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331734)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->