### PR TITLE
Add PerryLink/dsh-session-pin to Web UI, Skins & Desktop Pets

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The hottest category — giving text-only models "eyes."
 | [zizaiwo/dsh_plugins](https://github.com/zizaiwo/dsh_plugins) | Sidebar session categories for dsh Web UI: zero-config takeover of official workspace browser, organize sessions by custom folders (drag & drop, in-category creation, per-workspace isolation) | 0 |
 | [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) | Quick-prompts bar above composer: per-category snippet chips, orange {{placeholder}} highlighting, two-column management, per-session category memory | 0 |
 | [Moonshile/moonshile-dsh-plugins](https://github.com/Moonshile/moonshile-dsh-plugins) | Re-sorts sidebar workspaces by last activity once per day; stable order within the day | 0 |
+| [PerryLink/dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) | Pin sessions and workspaces to the top of the Web sidebar with per-pin row colors, a header toggle and a pinned panel; 0.4.0 adds a navigation organizer — pin groups (boards), tags and saved filter views, session health summaries, and /goto. | 3 |
 ### 🖥️ TUI & Desktop
 
 | Project | Description | ⭐ |
@@ -140,6 +141,7 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -103,6 +103,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [zizaiwo/dsh_plugins](https://github.com/zizaiwo/dsh_plugins) | dsh 侧边栏会话分类插件：零配置接管官方工作区浏览器，按自定义分类文件夹管理会话（拖拽归类/分类内建会话/每工作区独立） | 0 |
 | [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) | 输入框上方的快捷指令胶囊栏：按分类存常用 prompt，橙色高亮占位符，两栏管理，分类记忆按会话独立持久化 | 0 |
 | [Moonshile/moonshile-dsh-plugins](https://github.com/Moonshile/moonshile-dsh-plugins) | 侧边栏工作区每日按最近活动排序一次，当天顺序稳定 | 0 |
+| [PerryLink/dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) | 把会话与工作区置顶到 Web 侧边栏顶部：行级图钉与换色、会话头开关、已置顶面板；0.4.0 再加导航组织器——Pin 分组（boards）、标签与保存视图、会话健康摘要与 /goto。 | 3 |
 
 ### 🖥️ TUI 与桌面端
 
@@ -141,6 +142,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Pin sessions and workspaces to the top of the Web sidebar with per-pin row colors, a header toggle and a pinned panel; 0.4.0 adds a navigation organizer - pin groups (boards), tags and saved filter views, session health summaries, and /goto.
- **Install**: `dsh plugin --profile web add dsh-session-pin` (npm: dsh-session-pin@0.6.1)
- **License**: Apache-2.0 - **Stars**: 3 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Web UI, Skins & Desktop Pets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-session-pin` in both READMEs).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PerryLink/dsh-session-pin to the English and Chinese Web UI plugin tables, but also introduces an unrelated project not covered by the PR description.
- Adds matching dsh-session-pin entries with feature descriptions and star counts to both READMEs.
- Adds dsh-auto-review entries to both Tools, Workflows & Presets tables despite that project being outside the stated scope.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The unrelated dsh-auto-review entries should be removed or explicitly submitted and justified before merging.

Both READMEs introduce a second project that is absent from the PR’s title, description, categorization rationale, and duplicate-check statement, so the catalog change exceeds the reviewed scope.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds the requested session-pin listing but also an unexplained dsh-auto-review listing outside the PR’s declared scope. |
| README.zh.md | Mirrors both English additions, including the same unrelated dsh-auto-review catalog entry. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:144
**Unrelated catalog entry added**

This line adds `PerryLink/dsh-auto-review` to both curated READMEs even though the PR title, description, rationale, and duplicate check cover only `dsh-session-pin`, causing an additional project to enter the catalog without being submitted or justified for review.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-session-pin to W..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/6c0af902bf520c1a3e13cfe1dd7854cdb17e148e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331741)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## Summary by Sourcery

Expand the English and Chinese plugin catalogs with two additional community projects.

New Features:
- Add PerryLink/dsh-session-pin to the Web UI, Skins & Desktop Pets plugin listings in the English and Chinese READMEs.
- Add PerryLink/dsh-auto-review to the TUI & Desktop listings in the English and Chinese READMEs.

Documentation:
- Keep the English and Chinese plugin catalogs synchronized with the newly listed projects and their descriptions.