### PR TITLE
Add PerryLink/dsh-permission-rules to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) | Claude Code-style declarative permission rules: ordered allow/deny/ask YAML rules matching tool names, arguments, workspace paths, and agent identity on the tools/pre-execute waterfall, with full session-log audit, dry-run mode, and hot reload. | 69 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) | Claude Code 风格的声明式权限规则：按序 allow/deny/ask 的 YAML 规则，在 tools/pre-execute 瀑布上匹配工具名、参数、工作区路径与 agent 身份，带完整会话日志审计、干跑模式与热重载。 | 69 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Claude Code-style declarative permission rules: ordered allow/deny/ask YAML rules matching tool names, arguments, workspace paths, and agent identity on the tools/pre-execute waterfall, with full session-log audit, dry-run mode, and hot reload.
- **Install**: `dsh plugin --profile web add dsh-permission-rules` (npm: dsh-permission-rules@0.6.1)
- **License**: Apache-2.0 - **Stars**: 69 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-permission-rules` in both READMEs).

## Summary by Sourcery

Add dsh-permission-rules to the Tools, Workflows & Presets plugin listings in both project READMEs.

New Features:
- Add dsh-permission-rules to the Tools, Workflows & Presets catalog in the English and Chinese READMEs.

Documentation:
- Document the permission-rules plugin, including its declarative access controls, auditing, dry-run support, and hot reload capabilities.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds PerryLink plugin listings to the English and Chinese Tools, Workflows & Presets catalogs.
- Adds the intended dsh-permission-rules listing with matching bilingual descriptions.
- Also adds a separate dsh-auto-review listing that is outside the stated single-project scope.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation change is safe to merge after removing the unrelated dsh-auto-review entry or submitting it through its own pull request.

The bilingual dsh-permission-rules listing is structurally sound, but the additional dsh-auto-review row violates the repository's one-project-per-pull-request contribution requirement.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two validly formatted project rows, but one is an additional project outside the PR's stated scope and one-project contribution rule. |
| README.zh.md | Mirrors both English additions accurately, including the same out-of-scope second project. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated second project listing**

This PR also adds `dsh-auto-review`, although the title and supplied project details cover only `dsh-permission-rules`; this conflicts with the repository's one-project-per-PR requirement and publishes a second listing without its own contribution review.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-permission-rules..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/f295a1aed3ba42de458124b4b94849818b9f85c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331745)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->