### PR TITLE
Add PerryLink/dsh-mcp-panel to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) | Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors, and reconnect counts through the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions. | 52 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) | 官方 MCP 客户端（dsh-mcp-client）的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。 | 52 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors, and reconnect counts through the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions.
- **Install**: `dsh plugin --profile web add dsh-mcp-panel` (npm: dsh-mcp-panel@0.6.1)
- **License**: Apache-2.0 - **Stars**: 52 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-mcp-panel` in both READMEs).

## Summary by Sourcery

List the dsh-mcp-panel plugin in the project’s English and Chinese tool catalogs.

New Features:
- Add PerryLink/dsh-mcp-panel to the Tools, Workflows & Presets listings in both English and Chinese READMEs.

Documentation:
- Document the MCP panel’s read-only runtime status, tool, error, and reconnect monitoring capabilities and installation command.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds bilingual catalog entries under Tools, Workflows & Presets.
- Adds the requested PerryLink/dsh-mcp-panel entry to both READMEs.
- Also adds PerryLink/dsh-auto-review, which is outside the stated single-project submission scope.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The extra dsh-auto-review listing should be removed and submitted separately before this PR is merged.

The PR is scoped and verified as a dsh-mcp-panel submission, but both READMEs also publish a second project that bypasses the repository's one-project-per-PR review flow.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds the requested plugin but also includes an additional project not identified by the PR. |
| README.zh.md | Mirrors both additions in Chinese, including the same out-of-scope project. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Extra project bypasses review**

When this PR is reviewed as the advertised `dsh-mcp-panel` submission, it also adds `dsh-auto-review`, causing a second project to enter the catalog without the repository's one-project-per-PR review and verification flow.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-mcp-panel to Too..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/f2aa9aaa01b3ade613f5b5bc80b289eacff7f43b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331759)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->