### PR TITLE
Add PerryLink/dsh-research-report to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | Verifiable research-report engine for DeepSeek Harness with a content-addressed evidence ledger, versioned sealed reports where every claim carries a verification verdict and the manifest hash seals the directory, and retrieval orchestration that reuses the ctx.web and ctx.jobs seams. | 25 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | DeepSeek Harness 的可核查研究报告引擎：通过内容寻址的证据台账和版本化封存报告使每条结论携带核查结论，由 manifest 哈希封存目录，检索编排复用 ctx.web 与 ctx.jobs 接口。 | 25 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Verifiable research-report engine for DeepSeek Harness with a content-addressed evidence ledger, versioned sealed reports where every claim carries a verification verdict and the manifest hash seals the directory, and retrieval orchestration that reuses the ctx.web and ctx.jobs seams.
- **Install**: `dsh plugin --profile web add dsh-research-report` (npm: dsh-research-report@0.3.0)
- **License**: Apache-2.0 - **Stars**: 25 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-research-report` in both READMEs).

## Summary by Sourcery

List the dsh-research-report plugin in the project’s English and Chinese tool catalogs.

New Features:
- Add the PerryLink/dsh-research-report plugin to the Tools, Workflows & Presets listings in the English and Chinese READMEs.

Documentation:
- Document the research-report plugin in both language-specific project catalogs, including its purpose, installation command, and current popularity.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PerryLink/dsh-research-report to the English and Chinese Tools, Workflows & Presets lists, but also includes an unrelated second project.
- Adds bilingual descriptions and star counts for dsh-research-report.
- Also adds dsh-auto-review despite the repository's one-project-per-PR requirement.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The unrelated dsh-auto-review listing should be removed before merging so this submission remains limited to the project described by the PR.

Both READMEs include a second project even though the contribution checklist permits only one project per pull request.

**Files Needing Attention:** README.md, README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds the intended research-report listing and an out-of-scope second project. |
| README.zh.md | Mirrors both English additions in Chinese, including the out-of-scope second project. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated second project added**

This PR is submitted for `dsh-research-report`, but it also adds `dsh-auto-review` to both project lists, violating the one-project-per-PR contribution requirement and publishing a project outside this submission's stated scope.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-research-report ..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/3513ec4915b5db3777391b1d4735e1fa2a83f962) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331781)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->