### PR TITLE
Add PerryLink/dsh-industry-research to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-industry-research](https://github.com/PerryLink/dsh-industry-research) | Deterministic industry research reports for DeepSeek Harness — company and industry research flows produce structured, verifiable reports from staged evidence. | 22 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-industry-research](https://github.com/PerryLink/dsh-industry-research) | 面向 DeepSeek Harness 的确定性行业研究报告：公司与行业研究流程基于分阶段证据产出结构化、可核验的报告。 | 22 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Deterministic industry research reports for DeepSeek Harness - company and industry research flows produce structured, verifiable reports from staged evidence.
- **Install**: `dsh plugin --profile web add dsh-industry-research` (npm: dsh-industry-research@0.3.0)
- **License**: Apache-2.0 - **Stars**: 22 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-industry-research` in both READMEs).

## Summary by Sourcery

Add dsh-industry-research to the Tools, Workflows & Presets listings.

New Features:
- Add the dsh-industry-research plugin to the English and Chinese Tools, Workflows & Presets catalogs.

Documentation:
- Document the plugin’s deterministic company and industry research capabilities and repository links in both README files.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates both language variants of the project catalog with PerryLink tooling.
- Adds PerryLink/dsh-industry-research under Tools, Workflows & Presets.
- Also adds PerryLink/dsh-auto-review, which is outside the stated single-project scope.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation change is safe to merge after removing the unrelated dsh-auto-review listing and submitting it separately.

The bilingual industry-research listing is consistent, but the diff also publishes a second project contrary to the repository's one-project-per-PR contribution process.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two PerryLink catalog rows; the dsh-auto-review row conflicts with the one-project-per-PR contribution requirement. |
| README.zh.md | Mirrors both new listings in Chinese, including the unrelated dsh-auto-review entry. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated second project added**

This row adds `PerryLink/dsh-auto-review` alongside the project declared by this PR, contrary to the repository's one-project-per-PR requirement. Merging it would publish a second project without the dedicated contribution and project-specific validation required for each listing; please move both language variants to a separate PR.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-industry-researc..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/25d87183e7da3bf02b14a59fbe5499a8b88a7ea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331816)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->