### PR TITLE
Add PerryLink/dsh-checkpoint-rewind to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-checkpoint-rewind](https://github.com/PerryLink/dsh-checkpoint-rewind) | Claude Code /rewind for DeepSeek Harness: git-first workspace snapshots before every mutating tool execution, turn-boundary session forks, and a one-shot /rewind command that restores files and forks the session back to a checkpoint. | 12 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-checkpoint-rewind](https://github.com/PerryLink/dsh-checkpoint-rewind) | DeepSeek Harness 的 Claude Code /rewind 等价能力：每次变更型工具执行前捕获 git 优先的工作区文件快照，轮次边界 fork 会话，一条 /rewind 命令恢复文件并把会话回退到检查点。 | 12 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Claude Code /rewind for DeepSeek Harness: git-first workspace snapshots before every mutating tool execution, turn-boundary session forks, and a one-shot /rewind command that restores files and forks the session back to a checkpoint.
- **Install**: `dsh plugin --profile web add dsh-checkpoint-rewind` (npm: dsh-checkpoint-rewind@0.6.1)
- **License**: Apache-2.0 - **Stars**: 12 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-checkpoint-rewind` in both READMEs).

## Summary by Sourcery

List the dsh-checkpoint-rewind workspace checkpoint and session rewind plugin in the Tools, Workflows & Presets catalogues.

New Features:
- Add the dsh-checkpoint-rewind plugin to the Tools, Workflows & Presets listings in the English and Chinese READMEs.

Documentation:
- Document the plugin’s checkpoint, rewind, and session-fork capabilities in both language-specific catalogues.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds dsh-checkpoint-rewind to the English and Chinese Tools, Workflows & Presets tables.
- Describes git-backed workspace checkpoints, session forks, and `/rewind`.
- Also adds an unrelated dsh-auto-review listing despite the one-project-per-PR convention.
- Omits checkpoint-rewind installation instructions from both localized entries.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation change is safe to merge after addressing the non-blocking scope and installation-detail issues.

The listed checkpoint plugin lacks the repository-required installation detail, and the diff also includes a second project that should be submitted and reviewed separately.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two PerryLink tools; the unrelated auto-review row exceeds the declared PR scope, and checkpoint-rewind lacks the required installation method. |
| README.zh.md | Mirrors both additions in Chinese, including the same extra-project and missing-installation issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated second project added**

This row adds `dsh-auto-review` even though the PR is scoped to `dsh-checkpoint-rewind`, violating the repository's one-project-per-PR requirement and bypassing a separately scoped contribution review.

### Issue 2
README.md:144
**Installation command omitted**

The new checkpoint-rewind entry omits the installation method required by the contribution template, leaving readers unable to obtain the supported command from either localized listing or a generic installation section.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-checkpoint-rewin..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/b4d15fb188e857c41fb479194b1afdb550f76157) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331835)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->