### PR TITLE
Add PerryLink/dsh-claude-move to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | Four-source migration wizard: move Claude Code, Codex, OpenCode and Hermes sessions, memories, skills, instructions and slash commands into DSH (/move wizard with approval gate and idempotent move.json, resumable sessions). | 12 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | 四合一迁移向导：把 Claude Code、Codex、OpenCode、Hermes 的会话、记忆、技能、指令与斜杠命令迁入 DSH（/move 向导，审批门 + 幂等 move.json，会话可续聊）。 | 12 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Four-source migration wizard: move Claude Code, Codex, OpenCode and Hermes sessions, memories, skills, instructions and slash commands into DSH (/move wizard with approval gate and idempotent move.json, resumable sessions).
- **Install**: `dsh plugin --profile web add dsh-claude-move` (npm: dsh-claude-move@0.3.0)
- **License**: Apache-2.0 - **Stars**: 12 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-claude-move` in both READMEs).

## Summary by Sourcery

Add the dsh-claude-move migration wizard to the project’s curated plugin listings.

New Features:
- Add PerryLink/dsh-claude-move to the Tools, Workflows & Presets listings in both English and Chinese READMEs.

Documentation:
- Document the plugin’s four-source migration capabilities and installation link in both README language versions.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the dsh-claude-move migration plugin to the English and Chinese Tools, Workflows & Presets catalogs, but also includes an unrelated project outside the stated scope.
- Adds an English description and star count for dsh-claude-move.
- Adds the corresponding Chinese catalog entry.
- Also adds dsh-auto-review to both catalogs without mentioning it in the PR scope.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The unrelated dsh-auto-review entries should be removed or explicitly brought into this PR's scope before merging.

Both localized catalogs contain an additional project that is not identified or justified by the stated dsh-claude-move change.

**Files Needing Attention:** README.md, README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds the intended dsh-claude-move listing, plus an unrelated dsh-auto-review row that should be separated from this PR. |
| README.zh.md | Mirrors both additions in Chinese, including the same out-of-scope dsh-auto-review entry. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated catalog entry added**

This PR is scoped to `dsh-claude-move`, but it also adds `dsh-auto-review` to both localized catalogs, causing an unrelated project to bypass a separately scoped and documented review.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-claude-move to T..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/fb4fc9475d6ceb43916cf36b4e2287a95f75c053) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331864)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->