### PR TITLE
Add PerryLink/dsh-lsp-actions to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-lsp-actions](https://github.com/PerryLink/dsh-lsp-actions) | LSP action surface for DSH: diagnostics, formatting, completion, code actions, symbols, signature help, inlay hints and rename, all backed by real language servers. | 11 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-lsp-actions](https://github.com/PerryLink/dsh-lsp-actions) | DSH 的 LSP 动作面：诊断、格式化、补全、代码动作、符号、签名提示、inlay 提示与重命名，全部由真实语言服务器驱动。 | 11 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: LSP action surface for DSH: diagnostics, formatting, completion, code actions, symbols, signature help, inlay hints and rename, all backed by real language servers.
- **Install**: `dsh plugin --profile web add dsh-lsp-actions` (npm: dsh-lsp-actions@0.4.0)
- **License**: Apache-2.0 - **Stars**: 11 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-lsp-actions` in both READMEs).

## Summary by Sourcery

Add the dsh-lsp-actions plugin to the project’s bilingual Tools, Workflows & Presets catalogs.

Enhancements:
- Add PerryLink/dsh-lsp-actions to the Tools, Workflows & Presets listings in both English and Chinese catalogs.

Documentation:
- Document the DSH LSP actions plugin, including its language-server-backed diagnostics, formatting, completion, code actions, symbols, signature help, inlay hints, and rename capabilities.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds English and Chinese catalog entries for dsh-lsp-actions under Tools, Workflows & Presets, together with an additional dsh-auto-review listing.
- Describes the LSP-backed diagnostics, formatting, completion, refactoring, and navigation actions.
- Records star counts for both newly listed PerryLink projects.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after the non-blocking catalog-scope and installation-documentation issues are addressed.

The bilingual entries are synchronized and correctly categorized, but the diff includes an unrelated second project contrary to the contribution scope and omits the actionable installation command from the requested listing.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two English catalog rows; the extra project exceeds the one-project PR scope, and the requested plugin row omits its supplied installation command. |
| README.zh.md | Adds synchronized Chinese rows with the same scope and installation-documentation concerns. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated project added**

This PR adds `dsh-auto-review` even though the submission is scoped to `dsh-lsp-actions`, violating the repository's one-project-per-PR requirement and allowing an additional catalog entry to bypass an independently scoped review.

### Issue 2
README.md:144
**Installation command omitted**

The new description omits the supplied `dsh plugin --profile web add dsh-lsp-actions` command in both READMEs, making the catalog entry less actionable than the contribution template prescribes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-lsp-actions to T..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/7e7221b27296cb9c1b99b711bf56cbba11ecf060) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331880)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->