### PR TITLE
Add PerryLink/dsh-doublecheck to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | Engineering-discipline guard: requirements grill before the first edit, red/green test-evidence gates, forked adversary review, and a delivery report with a per-dimension verification workflow. | 10 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | 工程纪律守门：动笔前审讯需求，红绿测试证据门，交付后对抗评审，并汇总交付报告与逐维度核对。 | 10 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Engineering-discipline guard: requirements grill before the first edit, red/green test-evidence gates, forked adversary review, and a delivery report with a per-dimension verification workflow.
- **Install**: `dsh plugin --profile web add dsh-doublecheck` (npm: dsh-doublecheck@0.9.0)
- **License**: Apache-2.0 - **Stars**: 10 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-doublecheck` in both READMEs).

## Summary by Sourcery

Add the dsh-doublecheck engineering-discipline plugin to the project’s tool catalogs.

New Features:
- Add PerryLink/dsh-doublecheck to the Tools, Workflows & Presets listings in the English and Chinese READMEs.

Documentation:
- Document the dsh-doublecheck plugin and its engineering-discipline verification workflow in both language-specific README catalogs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds PerryLink/dsh-doublecheck to the Tools, Workflows & Presets tables in both English and Chinese. It also adds PerryLink/dsh-auto-review, despite the PR being scoped to one project.
- Adds English and Chinese descriptions and star counts for dsh-doublecheck.
- Adds an additional bilingual dsh-auto-review listing with installation guidance.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after the non-blocking extra dsh-auto-review listing is removed or moved to a separately scoped contribution.

The bilingual dsh-doublecheck addition is structurally sound, but the same change also bundles an undisclosed second project contrary to the repository’s contribution guidance.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two English tool listings; the dsh-auto-review row is an undisclosed second project contrary to the one-project-per-PR contribution rule. |
| README.zh.md | Mirrors both additions in Chinese, including the same out-of-scope dsh-auto-review listing. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Undisclosed second project listing**

This row adds `dsh-auto-review` even though the PR is scoped to `dsh-doublecheck`, bundling an independently reviewable project contrary to the repository's one-project-per-PR contribution guidance.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-doublecheck to T..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/2288503f66c352b9c9761d0ab85838335e9e902b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331883)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->