### PR TITLE
Add PerryLink/dsh-fund-research to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-fund-research](https://github.com/PerryLink/dsh-fund-research) | Deterministic research reports for Chinese public mutual funds built from public-source data (Tiantian Fund and Eastmoney), pure-function metrics (performance decomposition, holdings penetration, style attribution, manager profile), and versioned reports with a per-number snapshot traceability appendix. | 10 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-fund-research](https://github.com/PerryLink/dsh-fund-research) | 中国公募基金确定性研究报告：采集天天基金/东方财富公开数据，纯函数计算业绩拆解、持仓穿透、风格归因与经理画像，输出带逐数字可溯源快照附录的版本化报告。 | 10 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Deterministic research reports for Chinese public mutual funds built from public-source data (Tiantian Fund and Eastmoney), pure-function metrics (performance decomposition, holdings penetration, style attribution, manager profile), and versioned reports with a per-number snapshot traceability appendix.
- **Install**: `dsh plugin --profile web add dsh-fund-research` (npm: dsh-fund-research@0.3.0)
- **License**: Apache-2.0 - **Stars**: 10 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-fund-research` in both READMEs).

## Summary by Sourcery

List the dsh-fund-research plugin in the project’s English and Chinese tool catalogs.

Enhancements:
- Add the PerryLink/dsh-fund-research plugin to the Tools, Workflows & Presets listings in both English and Chinese READMEs.

Documentation:
- Document the plugin’s deterministic Chinese mutual-fund research and traceable, versioned reporting capabilities in both language-specific catalogs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds English and Chinese catalog entries for PerryLink/dsh-fund-research, along with an additional PerryLink/dsh-auto-review entry not identified in the pull request scope.
- Adds fund-research descriptions and a star count to both Tools, Workflows & Presets tables.
- Adds parallel auto-review entries to both language versions.
- Preserves matching links, metadata, placement, and translated descriptions across the two READMEs.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after addressing two non-blocking documentation concerns about the unannounced extra project and the missing DSH relationship in the fund-research descriptions.

The bilingual rows are internally consistent, but one addition is not represented in the pull request scope and the primary fund-research entry omits the DSH integration required for catalog eligibility.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two tool entries; the auto-review row is outside the documented PR scope, and the fund-research row omits its DSH integration. |
| README.zh.md | Faithfully mirrors both English additions, including the same scope and missing-DSH-context concerns. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Undocumented Extra Project Entry**

This row adds `PerryLink/dsh-auto-review` even though the pull request is scoped exclusively to `PerryLink/dsh-fund-research`, allowing an additional project to enter the catalog without the eligibility, license, metadata, and duplicate-check information provided for the named submission.

### Issue 2
README.md:144
**Missing DSH Integration Context**

The new description covers the fund-research functionality but omits its relationship to DSH and its plugin installation path, so readers cannot see the basis for the project's catalog eligibility from the entry itself as required by `CONTRIBUTING.md`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-fund-research to..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/5105c151402e65612c5218e7c52710f939e1beb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331889)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->