### PR TITLE
Add PerryLink/dsh-background-agents to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-background-agents](https://github.com/PerryLink/dsh-background-agents) | Durable background child agents on the official subagent seam: start from any session, watch progress in the Web UI sidebar, message and interrupt any time, with per-child tool scoping, persona and delegation-depth caps. | 8 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-background-agents](https://github.com/PerryLink/dsh-background-agents) | 官方子代理接缝上的持久化后台子代理：任意会话中启动，Web 侧边栏看进度、随时留言与打断，支持按子代理限定工具、人格与委托深度。 | 8 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Durable background child agents on the official subagent seam: start from any session, watch progress in the Web UI sidebar, message and interrupt any time, with per-child tool scoping, persona and delegation-depth caps.
- **Install**: `dsh plugin --profile web add dsh-background-agents` (npm: dsh-background-agents@0.6.0)
- **License**: Apache-2.0 - **Stars**: 8 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-background-agents` in both READMEs).

## Summary by Sourcery

Enhancements:
- Add the dsh-background-agents plugin to the Tools, Workflows & Presets catalogs in both English and Chinese READMEs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds PerryLink/dsh-background-agents to the English and Chinese Tools, Workflows & Presets tables, but also includes an undisclosed PerryLink/dsh-auto-review entry.
- Documents dsh-background-agents and its star count in both catalog translations.
- Adds matching English and Chinese descriptions.
- Also adds dsh-auto-review outside the stated PR scope.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation-only PR is safe to merge after removing or separately disclosing and justifying the unrelated dsh-auto-review entry.

The requested background-agents listing is consistently added in both translations, but both files also silently introduce a second project that is absent from the PR title, rationale, and metadata.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two English catalog rows; the dsh-auto-review row is unrelated to the project described by the PR. |
| README.zh.md | Mirrors both additions in Chinese, including the same out-of-scope dsh-auto-review entry. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated catalog entry**

This PR also adds `PerryLink/dsh-auto-review` to both catalog translations, although the title and description only propose `dsh-background-agents`; this expands the catalog without the rationale and metadata needed to review the second project.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-background-agent..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/6880e22ac5401b6cfcacdc83bc754c03b918a2ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331898)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->