### PR TITLE
Add PerryLink/dsh-data-quality to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) | Data quality checking for DeepSeek Harness — profiling, cleaning, and verification pipelines with structured reports. | 6 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) | DeepSeek Harness 的数据质量检查：数据画像、清洗与验证流水线，产出结构化报告。 | 6 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Data quality checking for DeepSeek Harness - profiling, cleaning, and verification pipelines with structured reports.
- **Install**: `dsh plugin --profile web add dsh-data-quality` (npm: dsh-data-quality@0.3.0)
- **License**: Apache-2.0 - **Stars**: 6 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-data-quality` in both READMEs).

## Summary by Sourcery

Add the dsh-data-quality plugin to the Tools, Workflows & Presets listings.

New Features:
- Add PerryLink/dsh-data-quality to the Tools, Workflows & Presets catalog with descriptions in English and Chinese READMEs.

Documentation:
- Document the data-quality plugin as providing profiling, cleaning, and verification pipelines with structured reports.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PerryLink/dsh-data-quality to the Tools, Workflows & Presets tables in both English and Chinese, but also bundles an unrelated project despite the repository’s one-project-per-PR policy.
- Adds an English description and star count for dsh-data-quality.
- Adds the corresponding localized Chinese entry.
- Also adds dsh-auto-review to both catalogs.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation change is non-blocking, but the unrelated dsh-auto-review rows should be removed and submitted in a separate pull request.

The requested project is consistently added to both catalogs, while the only concern is that a second project is bundled contrary to the repository’s contribution policy.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds the requested data-quality project but also includes an unrelated project that should be submitted separately. |
| README.zh.md | Mirrors both additions in Chinese, including the same out-of-scope dsh-auto-review entry. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated project bundled**

This PR also adds `PerryLink/dsh-auto-review` to both language catalogs, even though the submission is for `dsh-data-quality` and the contribution policy limits each PR to one project. This bypasses an independent submission for the additional entry and makes the PR history attribute both additions to `dsh-data-quality`; remove this row and its Chinese counterpart for a separate PR.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-data-quality to ..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/8475130925daf31b3878c966ad1f67858016daf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331904)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->