### PR TITLE
Add PerryLink/dsh-skill-pack-security to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | Security-audit methodology skill pack plus the plugin_vet supply-chain gate: eight agent skills (secret scan, dependency audit, supply-chain review, prompt-injection review, audit orchestration, threat modeling, vuln intel, incident response) in Chinese and English editions, with an npm provider bundle that mounts the skills and registers the automated plugin_vet pre-install scanner. | 6 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | 安全审计方法论技能包 + plugin_vet 供应链门禁：八个 agent 技能（密钥扫描、依赖审计、供应链评审、提示注入审查、审计总编排、威胁建模、漏洞情报、事件响应），中英双版本，附 npm provider 包一键挂载并注册自动化 plugin_vet 安装前扫描。 | 6 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Security-audit methodology skill pack plus the plugin_vet supply-chain gate: eight agent skills (secret scan, dependency audit, supply-chain review, prompt-injection review, audit orchestration, threat modeling, vuln intel, incident response) in Chinese and English editions, with an npm provider bundle that mounts the skills and registers the automated plugin_vet pre-install scanner.
- **Install**: `dsh plugin --profile web add dsh-skill-pack-security`
- **License**: Apache-2.0 - **Stars**: 6 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-skill-pack-security` in both READMEs).

## Summary by Sourcery

Add the security auditing skill pack to the project’s tool catalog.

New Features:
- Add PerryLink/dsh-skill-pack-security to the Tools, Workflows & Presets listings in both English and Chinese READMEs.

Documentation:
- Document the security-audit skill pack, its bilingual agent skills, and plugin_vet supply-chain scanning capabilities.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation PR adds PerryLink project listings to the English and Chinese catalogs under Tools, Workflows & Presets.
- Adds the requested dsh-skill-pack-security listing with synchronized bilingual descriptions and star counts.
- Also adds dsh-auto-review to both catalogs, exceeding the declared one-project scope.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation change is safe to merge after the unrelated dsh-auto-review listing is moved to its own pull request.

The bilingual entries are formatted and synchronized correctly, but adding two projects in a submission declared for one project violates the repository's contribution scope rule.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds synchronized English entries for dsh-skill-pack-security and an undeclared second project, dsh-auto-review. |
| README.zh.md | Adds matching Chinese entries, preserving bilingual alignment but repeating the extra out-of-scope project addition. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Undeclared second project**

This PR also adds `PerryLink/dsh-auto-review` to both catalogs, despite the one-project-per-PR rule and the declared scope covering only `dsh-skill-pack-security`; this unrelated entry should be submitted separately.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-skill-pack-secur..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/00be743f589e821b2c904ca5282f3044725cf092) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331911)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->