### PR TITLE
Add PerryLink/dsh-talk to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-talk](https://github.com/PerryLink/dsh-talk) | Voice-first session loop for DeepSeek Harness: a composer microphone button with speech-to-text, a speak tool for spoken text-to-speech replies, and speak-to-interrupt. | 5 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-talk](https://github.com/PerryLink/dsh-talk) | DeepSeek Harness 的语音优先会话闭环：作曲器麦克风按钮语音转文字、speak 工具朗读回复，支持打断说话。 | 5 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Voice-first session loop for DeepSeek Harness: a composer microphone button with speech-to-text, a speak tool for spoken text-to-speech replies, and speak-to-interrupt.
- **Install**: `dsh plugin --profile web add dsh-talk` (npm: dsh-talk@0.2.1)
- **License**: Apache-2.0 - **Stars**: 5 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-talk` in both READMEs).

## Summary by Sourcery

List the dsh-talk voice interaction plugin in the project’s bilingual tools directories.

New Features:
- Add PerryLink/dsh-talk to the Tools, Workflows & Presets listings in both English and Chinese READMEs.

Documentation:
- Document dsh-talk as a voice-first DeepSeek Harness plugin with speech-to-text, text-to-speech, and voice interruption support.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the English and Chinese Tools, Workflows & Presets tables with dsh-talk voice-session integration metadata and also adds a dsh-auto-review entry.
- Adds matching dsh-talk repository links, descriptions, and star counts to both READMEs.
- Adds matching dsh-auto-review listings that are not covered by the stated PR scope.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after addressing the non-blocking scope and Chinese translation issues.

The documentation renders correctly, but it includes an undeclared second project and a misleading Chinese translation of the message composer.

**Files Needing Attention:** README.md, README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds dsh-talk and an undeclared dsh-auto-review entry to the English project table. |
| README.zh.md | Mirrors both additions in Chinese, with “composer” mistranslated as the music-related “作曲器.” |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Undeclared project added**

This PR adds `dsh-auto-review` to both project tables even though the title, description, and stated duplicate check cover only `dsh-talk`, expanding the curated list beyond the declared scope.

### Issue 2
README.zh.md:145
**Composer is mistranslated**

Translating the session composer as `作曲器` describes a music-composition component, misleading Chinese readers about where the microphone button appears.

```suggestion
| [PerryLink/dsh-talk](https://github.com/PerryLink/dsh-talk) | DeepSeek Harness 的语音优先会话闭环：输入框麦克风按钮语音转文字、speak 工具朗读回复，支持打断说话。 | 5 |
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-talk to Tools, W..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/e09df58c0e4d1f9c4a41a27baffce2bef7e092fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331922)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->