### PR TITLE
Add PerryLink/dsh-local-ai to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-local-ai](https://github.com/PerryLink/dsh-local-ai) | Ollama provider for DeepSeek Harness with model management, health checks, rule-based local routing, and cloud fallback. | 4 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-local-ai](https://github.com/PerryLink/dsh-local-ai) | DeepSeek Harness 的 Ollama 接入：模型管理、健康检查、基于规则的本地路由与云端回退。 | 4 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Ollama provider for DeepSeek Harness with model management, health checks, rule-based local routing, and cloud fallback.
- **Install**: `dsh plugin --profile web add dsh-local-ai` (npm: dsh-local-ai@0.2.0)
- **License**: Apache-2.0 - **Stars**: 4 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-local-ai` in both READMEs).

## Summary by Sourcery

Add the dsh-local-ai Ollama provider to the project’s bilingual plugin catalogs.

New Features:
- Add PerryLink/dsh-local-ai to the Tools, Workflows & Presets listings in the English and Chinese READMEs.

Documentation:
- Document the Ollama-based local AI provider, including model management, health checks, local routing, and cloud fallback capabilities.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds dsh-local-ai to the Tools, Workflows & Presets tables in both English and Chinese, but also bundles an unrelated dsh-auto-review listing.
- Adds bilingual descriptions and star counts for dsh-local-ai.
- Adds matching bilingual entries for dsh-auto-review.
- Keeps the two README tables structurally synchronized.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation remains usable and synchronized, but the unrelated dsh-auto-review entry should be moved to a separate pull request.

The listings render correctly and introduce no blocking failure, while bundling a second project prevents the focused per-project review required by the contribution process.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two synchronized tool listings, although adding dsh-auto-review violates the repository's one-project-per-PR contribution rule. |
| README.zh.md | Faithfully mirrors both English additions, including the extra dsh-auto-review project. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated project bundled**

This PR adds `dsh-auto-review` alongside the intended `dsh-local-ai` listing, contrary to the one-project-per-PR contribution rule and preventing the extra project from receiving its own focused eligibility and metadata review.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-local-ai to Tool..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/756ffd52470584b96ba618d3f2f2a951d94aa0d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331933)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->