### PR TITLE
Add PerryLink/dsh-session-sync to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-session-sync](https://github.com/PerryLink/dsh-session-sync) | Cross-device session sync for DeepSeek Harness: a dedicated git mirror of the session store with append-only keep-both conflict resolution that never loses a turn. | 4 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-session-sync](https://github.com/PerryLink/dsh-session-sync) | DeepSeek Harness 的跨设备会话同步：会话存储的专用 git 镜像，追加式 keep-both 冲突解决，任何分歧都不丢回合。 | 4 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Cross-device session sync for DeepSeek Harness: a dedicated git mirror of the session store with append-only keep-both conflict resolution that never loses a turn.
- **Install**: `dsh plugin --profile web add dsh-session-sync` (npm: dsh-session-sync@0.2.0)
- **License**: Apache-2.0 - **Stars**: 4 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-session-sync` in both READMEs).

## Summary by Sourcery

Add the dsh-session-sync plugin to the project’s English and Chinese tool directories.

New Features:
- Add PerryLink/dsh-session-sync to the Tools, Workflows & Presets listings in the English and Chinese READMEs.

Documentation:
- Document the cross-device DeepSeek Harness session synchronization plugin in both language-specific project catalogs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation PR adds PerryLink/dsh-session-sync to the Tools, Workflows & Presets tables in both language variants, but also adds an unrelated dsh-auto-review listing.

- Adds English and Chinese descriptions for dsh-session-sync.
- Adds English and Chinese descriptions for dsh-auto-review despite the PR being scoped to one project.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is non-blocking but should remove dsh-auto-review and submit it separately to preserve the repository's per-project review process.

The bilingual dsh-session-sync addition is consistent, but both READMEs also add a second project that is not covered by this submission and conflicts with the documented one-project-per-PR requirement.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two PerryLink tool entries; the additional dsh-auto-review row conflicts with the one-project-per-PR contribution process. |
| README.zh.md | Mirrors both additions in Chinese, including the out-of-scope dsh-auto-review listing. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated second project listing**

This row adds `dsh-auto-review` through a PR whose title, description, installation details, and duplicate check cover only `dsh-session-sync`, bypassing the documented one-project-per-PR review process. Remove this row and its Chinese counterpart, and submit the project separately.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-session-sync to ..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/1330cda3b09a415eb5b82489e3d863f725ac3e75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331938)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->