### PR TITLE
Add PerryLink/dsh-budget to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) | Cost governance for DeepSeek Harness: budgets, carbon, and latency in one panel, with per-model, per-session, and per-day token metering, threshold alerts, and over-limit policies. | 3 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) | DeepSeek Harness 的成本治理：预算、碳足迹与延迟集成在一个面板，按模型/会话/天聚合 token 计量，带阈值告警与超限策略。 | 3 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Cost governance for DeepSeek Harness: budgets, carbon, and latency in one panel, with per-model, per-session, and per-day token metering, threshold alerts, and over-limit policies.
- **Install**: `dsh plugin --profile web add dsh-budget` (npm: dsh-budget@0.3.1)
- **License**: Apache-2.0 - **Stars**: 3 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-budget` in both READMEs).

## Summary by Sourcery

Add dsh-budget to the Tools, Workflows & Presets listings.

New Features:
- Add the dsh-budget plugin to the Tools, Workflows & Presets catalog in both English and Chinese READMEs.

Documentation:
- Document dsh-budget’s cost governance capabilities and repository details in both localized project catalogs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PerryLink project listings to the English and Chinese Tools, Workflows & Presets tables.
- Adds the intended dsh-budget listing with cost-governance, metering, alerting, and policy details.
- Also adds an unrelated dsh-auto-review listing that is not identified in the PR title or description.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after removing or explicitly documenting the unrelated dsh-auto-review listing.

The intended dsh-budget documentation is consistent across both READMEs, but the same change also publishes a second project that is outside the stated scope.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds English catalog entries for dsh-budget and an unrelated, undocumented dsh-auto-review project. |
| README.zh.md | Mirrors both additions in Chinese, including the unrelated dsh-auto-review entry. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated catalog entry**

This line adds `dsh-auto-review`, although the PR title and description cover only `dsh-budget`; publishing the unmentioned project makes the catalog update and its history misleading. Remove it from both README tables or explicitly include and justify it in the PR scope.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-budget to Tools,..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/46970970f18659123097e64f5f8ad41d8cb44a31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331949)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->