### PR TITLE
Add PerryLink/dsh-click to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-click](https://github.com/PerryLink/dsh-click) | Cross-platform native desktop control for DeepSeek Harness (Windows first): screen_shot, screen_read, click, type, scroll, and key actions with approval gating and process identity verification. | 3 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-click](https://github.com/PerryLink/dsh-click) | DeepSeek Harness 的跨平台原生桌面控制（Windows 优先）：screen_shot、screen_read、click、type、scroll 与 key 动作，全部经审批门与进程身份校验。 | 3 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Cross-platform native desktop control for DeepSeek Harness (Windows first): screen_shot, screen_read, click, type, scroll, and key actions with approval gating and process identity verification.
- **Install**: `dsh plugin --profile web add dsh-click` (npm: dsh-click@0.2.0)
- **License**: Apache-2.0 - **Stars**: 3 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-click` in both READMEs).

## Summary by Sourcery

List PerryLink/dsh-click in the Tools, Workflows & Presets catalog across both project README translations.

New Features:
- Add the PerryLink/dsh-click desktop-control plugin to the Tools, Workflows & Presets listings in both English and Chinese READMEs.

Documentation:
- Document dsh-click as a cross-platform native desktop-control option for DeepSeek Harness, including its supported actions and security controls.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation PR adds PerryLink's dsh-click desktop-control plugin to the English and Chinese Tools catalogs, but also bundles a second project not identified by the submission.
- Adds bilingual dsh-click descriptions and a star count.
- Also adds dsh-auto-review rows to both catalogs, exceeding the documented one-project-per-PR scope.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge from a runtime perspective, but the unrelated dsh-auto-review listing should be removed and submitted separately.

The documentation is correctly formatted and bilingual, but bundling two projects conflicts with the repository's focused contribution workflow and expands the review beyond the advertised dsh-click submission.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds English catalog rows for dsh-click and the unrelated dsh-auto-review project; the latter should be submitted separately. |
| README.zh.md | Mirrors both additions in Chinese, including the same out-of-scope dsh-auto-review row. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated project bundled into PR**

This PR also adds `dsh-auto-review`, although the submission covers `dsh-click` and the contribution guide requires one project per PR; bundling it here expands the review scope and conflict risk instead of giving the project a focused submission.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-click to Tools, ..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/490d5ed00191d0d0a434c7f9cfbd3954a69ea2c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331959)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->