### PR TITLE
Add PerryLink/dsh-fast to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-fast](https://github.com/PerryLink/dsh-fast) | Read-only performance diagnostics for DeepSeek Harness: reports session load and restore timing, context-injection volume, and LLM cache hit rate, off the model hot path. | 3 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-fast](https://github.com/PerryLink/dsh-fast) | DeepSeek Harness 的只读性能诊断：报告会话加载/恢复耗时、上下文注入量与 LLM 缓存命中率，不占模型热路径。 | 3 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Read-only performance diagnostics for DeepSeek Harness: reports session load and restore timing, context-injection volume, and LLM cache hit rate, off the model hot path.
- **Install**: `dsh plugin --profile web add dsh-fast` (npm: dsh-fast@0.2.0)
- **License**: Apache-2.0 - **Stars**: 3 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-fast` in both READMEs).

## Summary by Sourcery

Add dsh-fast to the Tools, Workflows & Presets listings.

New Features:
- Add PerryLink/dsh-fast to the English and Chinese Tools, Workflows & Presets catalogs as a read-only DeepSeek Harness performance diagnostics plugin.

Documentation:
- Document dsh-fast’s session timing, context-injection, and LLM cache diagnostics in both language-specific README catalogs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds dsh-fast to the English and Chinese Tools, Workflows & Presets catalogs, describing its read-only performance diagnostics and star count.
- Adds matching English and Chinese dsh-fast entries.
- Also adds an unmentioned dsh-auto-review entry to both catalogs.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation-only PR appears safe to merge after addressing the unrelated project addition and completing dsh-fast's installation details.

The bilingual entries are internally consistent and introduce no runtime risk, but the change bundles a second project contrary to the contribution scope and leaves the intended project's installation command out of the durable catalog.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two PerryLink projects, although the PR is scoped to dsh-fast, and omits dsh-fast's documented installation command. |
| README.zh.md | Mirrors both English additions and the same contribution-scope and installation-documentation concerns. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated project bundled into contribution**

This dsh-fast-scoped contribution also adds `PerryLink/dsh-auto-review` to both catalogs, bypassing the repository's one-project-per-PR process and its project-specific submission checks. Please move this separate project to its own contribution.

### Issue 2
README.md:144
**Installation command omitted**

The dsh-fast entry omits the documented `dsh plugin --profile web add dsh-fast` command from both catalog translations, leaving readers without the installation method required by the contribution format.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-fast to Tools, W..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/39d736a66f8353e9da39122f19ce180defab8bef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331965)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->