### PR TITLE
Add PerryLink/dsh-mask to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-mask](https://github.com/PerryLink/dsh-mask) | PII masking for DeepSeek Harness — anonymizes names, phones, emails, ids, and keys before requests and restores them at the display layer, keeping plaintext out of session logs. | 3 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-mask](https://github.com/PerryLink/dsh-mask) | DeepSeek Harness 的 PII 脱敏：请求前匿名化姓名、电话、邮箱、证件与密钥，展示层还原，明文不进入会话日志。 | 3 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: PII masking for DeepSeek Harness - anonymizes names, phones, emails, ids, and keys before requests and restores them at the display layer, keeping plaintext out of session logs.
- **Install**: `dsh plugin --profile web add dsh-mask` (npm: dsh-mask@0.2.1)
- **License**: Apache-2.0 - **Stars**: 3 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-mask` in both READMEs).

## Summary by Sourcery

Add the dsh-mask PII protection plugin to the project’s bilingual tools catalog.

New Features:
- Add PerryLink/dsh-mask to the Tools, Workflows & Presets catalog in both English and Chinese READMEs.

Documentation:
- Document the dsh-mask plugin’s PII masking capabilities and installation link in both project language READMEs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds PerryLink’s dsh-mask PII-masking plugin to the English and Chinese Tools, Workflows & Presets tables. It also adds a separate dsh-auto-review project that is not identified in the PR title or description.

- Adds bilingual dsh-mask listings with descriptions and star count.
- Adds bilingual dsh-auto-review listings in the same category.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after the unrelated dsh-auto-review entry is moved to its own contribution.

The bilingual documentation remains synchronized, but the diff bundles two distinct projects despite the repository’s requirement that each PR add only one.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds two English project rows; the unadvertised dsh-auto-review row conflicts with the repository’s one-project-per-PR contribution convention. |
| README.zh.md | Mirrors both additions in Chinese, including the same out-of-scope dsh-auto-review listing. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated project bundled**

This PR adds `dsh-auto-review` even though the title and description cover only `dsh-mask`, violating the repository's one-project-per-PR convention and preventing this separate listing from receiving its own contribution and verification pass.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-mask to Tools, W..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/aca370a6d7ed985bf7b59c8c222d7a9d375e966d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331972)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->