### PR TITLE
Add PerryLink/dsh-observe to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-observe](https://github.com/PerryLink/dsh-observe) | Exports the session event stream to OpenTelemetry OTLP and Langfuse as sanitized, buffered traces and metrics, off by default. | 3 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-observe](https://github.com/PerryLink/dsh-observe) | 将会话事件流导出为 OpenTelemetry OTLP 与 Langfuse 的脱敏、缓冲 traces 与指标，默认关闭。 | 3 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Exports the session event stream to OpenTelemetry OTLP and Langfuse as sanitized, buffered traces and metrics, off by default.
- **Install**: `dsh plugin --profile web add dsh-observe` (npm: dsh-observe@0.2.0)
- **License**: Apache-2.0 - **Stars**: 3 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-observe` in both READMEs).

## Summary by Sourcery

Add the dsh-observe observability plugin to the Tools, Workflows & Presets catalogs.

New Features:
- Add dsh-observe to the English and Chinese Tools, Workflows & Presets catalogs, documenting its optional OpenTelemetry OTLP and Langfuse observability exports.

Documentation:
- Update both language-specific READMEs with the dsh-observe plugin listing and installation information.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates both project indexes with PerryLink plugin listings, adding the intended dsh-observe entry and an additional dsh-auto-review entry.

- Adds dsh-observe to Tools, Workflows & Presets in the English and Chinese READMEs.
- Also adds dsh-auto-review to both tables.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation change is safe to merge after removing the unrelated dsh-auto-review listing or submitting it through a separate pull request.

The intended dsh-observe listing is synchronized across both READMEs, but the diff also bundles a second project contrary to the repository’s one-project-per-PR contribution requirement.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds synchronized English listings for dsh-observe and dsh-auto-review; the second project exceeds the declared single-project scope. |
| README.zh.md | Adds matching Chinese listings, including the same undeclared second project. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Undeclared second project listing**

This PR is scoped to `dsh-observe`, but this row also adds `dsh-auto-review` to both indexes, bypassing the repository's one-project-per-PR review process. Remove it here and submit it separately so each catalog entry receives its required dedicated review.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-observe to Tools..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/55d1fd28a51eaf7d014864e4713355e6ea915d11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331986)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->