### PR TITLE
Add PerryLink/dsh-translate to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-translate](https://github.com/PerryLink/dsh-translate) | Tool-output repair layer for DeepSeek Harness — JSON schema enforcement, parameter mapping, and JSON repair for tool calls. | 2 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-translate](https://github.com/PerryLink/dsh-translate) | DeepSeek Harness 的工具输出修复层：JSON Schema 校验、参数映射与 JSON 修复。 | 2 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Tool-output repair layer for DeepSeek Harness - JSON schema enforcement, parameter mapping, and JSON repair for tool calls.
- **Install**: `dsh plugin --profile web add dsh-translate` (npm: dsh-translate@0.2.0)
- **License**: Apache-2.0 - **Stars**: 2 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-translate` in both READMEs).

## Summary by Sourcery

Add dsh-translate to the project’s tool catalog in both English and Chinese documentation.

New Features:
- Add PerryLink/dsh-translate to the Tools, Workflows & Presets listings in the English and Chinese READMEs.

Documentation:
- Document dsh-translate as a DeepSeek Harness tool-output repair layer with JSON schema enforcement, parameter mapping, and JSON repair capabilities.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds PerryLink/dsh-translate to the Tools, Workflows & Presets tables in both English and Chinese, but also introduces a second project outside the declared scope.

- Adds an English description and star count for dsh-translate.
- Adds the corresponding Chinese entry.
- Also adds dsh-auto-review to both catalogs despite the one-project-per-PR contribution rule.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation change is safe to merge after the unrelated dsh-auto-review entry is removed or moved to a separate pull request.

The dsh-translate entries are synchronized and well-formed, but adding dsh-auto-review in the same contribution violates the repository’s one-project-per-PR requirement.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds synchronized catalog entries, but the dsh-auto-review row is an unrelated second project that should be submitted separately. |
| README.zh.md | Mirrors both English additions correctly, including the same out-of-scope dsh-auto-review entry. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated second project added**

This PR is scoped to `dsh-translate`, but this row also adds `dsh-auto-review`, contrary to the repository's one-project-per-PR requirement and preventing it from receiving a separately scoped review. Remove this row and its Chinese counterpart or submit them in a separate PR.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-translate to Too..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/cce030c26af6fd7a1cab16d454490843f1c5a7cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331994)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->