### PR TITLE
Add PerryLink/dsh-score to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
+| [PerryLink/dsh-score](https://github.com/PerryLink/dsh-score) | Multi-dimensional quality scoring for DeepSeek Harness plugins that scores a repo or npm package across install success, maintenance activity, documentation completeness, security scan, and protocol compliance using real CLI evidence, and produces a JSON or Markdown leaderboard report. | 2 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
+| [PerryLink/dsh-score](https://github.com/PerryLink/dsh-score) | 为 DeepSeek Harness 插件提供多指标质量评分：基于真实的 CLI 证据对某个仓库或 npm 包在安装成功率、维护活跃度、文档完整度、安全扫描和协议合规五个维度打分，并生成 JSON 或 Markdown 排行榜报告。 | 2 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Multi-dimensional quality scoring for DeepSeek Harness plugins that scores a repo or npm package across install success, maintenance activity, documentation completeness, security scan, and protocol compliance using real CLI evidence, and produces a JSON or Markdown leaderboard report.
- **Install**: `dsh plugin --profile web add dsh-score` (npm: dsh-score@0.2.0)
- **License**: Apache-2.0 - **Stars**: 2 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Tools, Workflows & Presets is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-score` in both READMEs).

## Summary by Sourcery

List the dsh-score plugin in the Tools, Workflows & Presets catalogs across both README languages.

New Features:
- Add PerryLink/dsh-score to the Tools, Workflows & Presets listings in both English and Chinese READMEs.

Documentation:
- Document dsh-score as a plugin for multi-dimensional DeepSeek Harness plugin quality scoring with JSON and Markdown leaderboard reports.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the English and Chinese catalogs under Tools, Workflows & Presets.
- Adds the advertised PerryLink/dsh-score quality-scoring plugin.
- Also adds PerryLink/dsh-auto-review, exceeding the documented one-project-per-PR scope.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after removing the unrelated dsh-auto-review entry or submitting it through a separate pull request.

The dsh-score listing is consistently added to both catalogs, but the additional dsh-auto-review listing conflicts with the repository’s one-project-per-PR contribution requirement.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds bilingual catalog counterparts for dsh-score and an additional out-of-scope dsh-auto-review listing. |
| README.zh.md | Adds Chinese catalog entries matching both English additions, including the extra project. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated second project listing**

This dsh-score submission also adds dsh-auto-review to both language editions, conflicting with the repository's one-project-per-PR requirement and placing an unadvertised project in the curated catalog without a separately scoped review.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-score to Tools, ..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/3a986249cb6d295c732aaebdb2d250fdcb3fc6e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58332000)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->