### PR TITLE
Add PerryLink/dsh-plugin-guide to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The hottest category — giving text-only models "eyes."
 | [morluto/jacobian](https://github.com/morluto/jacobian) | Pure mathematics for agents: search examples/counterexamples, compute exactly, verify | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model auto-review for DSH approval requests: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default and auditable from the session log. Installable via `dsh plugin --profile web add dsh-auto-review` | 119 |
 
 ### 📚 Skills
 
@@ -160,6 +161,7 @@ The hottest category — giving text-only models "eyes."
 | [Mikuzjc/dsh-office-for-mso](https://github.com/Mikuzjc/dsh-office-for-mso) | DSH <-> Microsoft Office bridge skill: control open Word/Excel/PowerPoint via Office add-in (33 actions, AI-orchestrated) | 1 |
 | [suyukun/dsh-tech-selection](https://github.com/suyukun/dsh-tech-selection) | Model-agnostic technology-selection research protocol for any AI agent (DSH/Claude/Cursor/Codex): T1-T6 source tiers, quality gates, quantified trade-offs, traceable verdicts | 0 |
 | [morluto/rea](https://github.com/morluto/rea) | Reverse engineer anything with agents, from app behavior down to native binaries | 322 |
+| [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) | The DSH plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API reference and community gotchas, installed with the bundle so the agent can look things up while building a plugin. | 32 |
 
 ### 🚀 Apps & Runtimes Built on DSH
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [morluto/jacobian](https://github.com/morluto/jacobian) | 纯数学工具:搜索例子与反例、精确计算、独立验证 | 43 |
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | DSH 审批请求的第二模型自动评审：只读评审子代理返回带理由的结构化允许/拒绝裁决，默认故障关闭、全程可从会话日志审计。可通过 `dsh plugin --profile web add dsh-auto-review` 安装 | 119 |
 
 ### 📚 Skills 与技能包
 
@@ -161,6 +162,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [Mikuzjc/dsh-office-for-mso](https://github.com/Mikuzjc/dsh-office-for-mso) | DSH ↔ Microsoft Office 桥接技能：操控已打开的 Word/Excel/PowerPoint（33 动作、AI 编排、Office 插件） | 1 |
 | [suyukun/dsh-tech-selection](https://github.com/suyukun/dsh-tech-selection) | 面向任意 AI Agent 的技术选型研究协议（DSH/Claude/Cursor/Codex 通用）：T1-T6 信源分级、质量门禁、量化权衡、可追溯结论 | 0 |
 | [morluto/rea](https://github.com/morluto/rea) | 用 agent 逆向任何东西:从应用行为到原生二进制 | 322 |
+| [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) | DSH 插件开发知识库，作为按需加载的 agent 技能随 bundle 安装：官方约束、任务工作流、API 参考与社区踩坑，写插件时让 DSH 自己查。 | 32 |
 
 ### 🚀 集成 DSH 的应用与运行时
 


### PR DESCRIPTION
- **Relation to DSH**: Installable DSH bundle: the dsh-plugin-guide plugin-development knowledge base as an on-demand agent skill.
- **Install**: `dsh plugin --profile web add dsh-plugin-guide` (npm: dsh-plugin-guide@0.2.0)
- **License**: Apache-2.0 - **Stars**: 32 (as of 2026-08-30) - `dsh-plugin` topic set
- **Why here**: Skills is the closest category for this plugin.
- No duplicate (searched `PerryLink/dsh-plugin-guide` in both READMEs).

## Summary by Sourcery

New Features:
- Add the PerryLink/dsh-plugin-guide project to the Skills catalog in the English and Chinese READMEs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PerryLink/dsh-plugin-guide to the English and Chinese Skills catalogs, but also introduces a separate dsh-auto-review listing outside the stated scope.
- Adds bilingual dsh-plugin-guide entries with a star count of 32.
- Adds bilingual dsh-auto-review entries to the Tools, Workflows & Presets category.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after the non-blocking scope issue is resolved by removing dsh-auto-review or submitting it separately.

The dsh-plugin-guide entries are consistent across both catalogs, but the additional dsh-auto-review entry violates the repository's one-project-per-PR convention and bypasses the submission's single-repository metadata scope.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds both catalog entries in English; the unrelated dsh-auto-review row conflicts with the one-project-per-PR contribution rule. |
| README.zh.md | Mirrors both additions in Chinese, including the same out-of-scope second project. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:143
**Unrelated second project added**

This row adds `dsh-auto-review` to a PR scoped to `dsh-plugin-guide`, contrary to the repository's one-project-per-PR contribution rule. Its corresponding Chinese row is also included, so the unrelated project enters both catalogs outside the submission's single-repository metadata checks.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PerryLink/dsh-plugin-guide to ..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/95266ca6252689c68f8c3ec0f964124f19f25901) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58332042)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->