### PR TITLE
feat(curator): every 3 days + second AI gate (approve→merge, close→close)

### DIFF
--- a/.github/workflows/curator.yml
+++ b/.github/workflows/curator.yml
@@ -2,7 +2,7 @@ name: Curator — Opencode Headless (experimental)
 
 on:
   schedule:
-    - cron: '17 2 * * *'  # daily 02:17 UTC, staggered from track/discover
+    - cron: '17 2 */3 * *'  # every 3 days 02:17 UTC, staggered from track/discover
   workflow_dispatch:
   issues:
     types: [opened, edited, labeled]
@@ -179,6 +179,136 @@ jobs:
         run: |
           echo "::warning::PR creation blocked — enable 'Allow GitHub Actions to create and approve PRs' at https://github.com/organizations/awesome-deepseekharness/settings/actions"
           git ls-remote --heads origin curator/report-${{ github.run_id }} | head -n 5 || true
+
+      - name: Second AI review — auto merge or close (independent gate)
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -e
+          PR="${{ steps.cpr.outputs.pull-request-number }}"
+          echo "=== Second AI reviewer (independent gate) for PR #$PR ==="
+          echo "PR branch: ${{ steps.cpr.outputs.pull-request-branch }}"
+          echo "--- curator-report.md preview ---"
+          head -n 120 curator-report.md || true
+          echo "--- git diff preview ---"
+          git fetch origin "curator/report-${{ github.run_id }}" --depth 1 2>&1 | head -n 20 || true
+          git diff HEAD~1 --stat 2>&1 | head -n 30 || git diff --stat 2>&1 | head -n 30 || true
+
+          # Prepare reviewer prompt (independent audit, not just echo)
+          cat > /tmp/reviewer-prompt.md <<'PROMPT_EOF'
+          You are the Second AI Reviewer — independent gate for curator PRs.
+          Read curator-report.md on disk, run deterministic checks, and emit one DECISION line first.
+
+          Steps you MUST do via tools:
+          - read curator-report.md (full)
+          - bash: git diff origin/main...HEAD --stat or cat curator-report.md | head
+          - if report claims star drift, verify 1 sample via bash: gh api repos/owner/repo --jq .stargazers_count
+          - then output:
+          DECISION: APPROVE  # only if bilingual ✅, no duplicates, no broken links, report has Sources, and curator opinion is Approve or Needs discussion with low-risk star-refresh only
+          DECISION: CLOSE    # if report says "no actionable findings" / "No PR/Issue — health audit only" with no patch, or invalid/duplicate
+          DECISION: REQUEST_CHANGES # otherwise (minor bilingual/star drift within fixable range)
+
+          Then 2-3 sentence rationale citing file:line and gh api evidence.
+          PROMPT_EOF
+          cat /tmp/reviewer-prompt.md
+
+          REVIEW_MODEL="qwen3-coder-free"
+          SECOND_LOG="/tmp/second-ai.log"
+          DECISION="REQUEST_CHANGES"
+
+          if command -v opencode >/dev/null 2>&1; then
+            echo "Running second AI: opencode/$REVIEW_MODEL with --agent reviewer ..."
+            # Prefer reviewer agent; fallback to curator if reviewer not found
+            if [ -f .opencode/agent/reviewer.md ]; then
+              AGENT="reviewer"
+            else
+              AGENT="curator"
+            fi
+            set +e
+            timeout 170 opencode run --model "opencode/$REVIEW_MODEL" --agent "$AGENT" "$(cat /tmp/reviewer-prompt.md)" 2>&1 | tee "$SECOND_LOG"
+            OC_EXIT=${PIPESTATUS[0]}
+            set -e
+            echo "opencode exit: $OC_EXIT"
+            if [ -f "$SECOND_LOG" ] && grep -q "DECISION: APPROVE" "$SECOND_LOG"; then
+              DECISION="APPROVE"
+            elif grep -q "DECISION: CLOSE" "$SECOND_LOG"; then
+              DECISION="CLOSE"
+            elif grep -q "DECISION: REQUEST_CHANGES" "$SECOND_LOG"; then
+              DECISION="REQUEST_CHANGES"
+            else
+              echo "Second AI did not emit clear DECISION, falling back to deterministic parse of curator-report.md"
+            fi
+          else
+            echo "opencode not found — deterministic fallback"
+          fi
+
+          # Deterministic fallback: parse curator-report.md's Maintainer Review Opinion + health
+          if [ "$DECISION" = "REQUEST_CHANGES" ]; then
+            if grep -q "RECOMMEND: Approve" curator-report.md; then
+              echo "Fallback: curator says Approve → treat as APPROVE"
+              DECISION="APPROVE"
+            elif grep -q "no actionable findings" curator-report.md || grep -qi "No PR/Issue.*health audit only" curator-report.md; then
+              # Check if health audit found major drift (>20%) — if yes, it's actionable, don't close lightly
+              if grep -q "STALE\|drift.*>20%\|\+.*% 🔴" curator-report.md; then
+                echo "Fallback: health audit has actionable star drift → REQUEST_CHANGES (needs star refresh, not close)"
+                DECISION="REQUEST_CHANGES"
+              else
+                echo "Fallback: no actionable findings → CLOSE"
+                DECISION="CLOSE"
+              fi
+            fi
+          fi
+
+          echo "=== Final DECISION: $DECISION ==="
+          echo "$DECISION" > /tmp/decision.txt
+
+          if [ "$DECISION" = "APPROVE" ]; then
+            echo "✅ Second AI approves → auto-merging PR #$PR"
+            gh pr review "$PR" --approve --body "✅ **Second AI reviewer** (\`opencode/$REVIEW_MODEL\` via \`reviewer\` agent) independently approves.
+
+          - Verified \`curator-report.md\` has Sources + bilingual ✅ + no duplicates
+          - Star drift is documented, low-risk
+          - Auto-merge after first AI curator + second AI gate.
+
+          *If branch protection blocks, maintainer please merge manually.*" || echo "approve failed"
+            # Try squash merge; fallback to merge
+            if gh pr merge "$PR" --squash --delete-branch 2>&1 | tee /tmp/merge.log; then
+              echo "Merged via squash"
+            elif gh pr merge "$PR" --merge --delete-branch 2>&1 | tee /tmp/merge.log; then
+              echo "Merged via merge"
+            else
+              echo "Merge failed (branch protection?) — leaving approved for manual merge"
+              gh pr comment "$PR" --body "⚠️ Second AI approved but auto-merge blocked by branch protection. Please merge manually. \`gh pr merge $PR --squash\`" || true
+            fi
+          elif [ "$DECISION" = "CLOSE" ]; then
+            echo "❌ Second AI says CLOSE → closing PR #$PR"
+            gh pr comment "$PR" --body "❌ **Second AI reviewer** (\`opencode/$REVIEW_MODEL\`) decision: **CLOSE**
+
+          - Reason: \`curator-report.md\` shows no actionable findings / health audit only, or duplicate/invalid.
+          - Reviewer log preview:
+          \`\`\`
+          $(head -n 60 "$SECOND_LOG" 2>/dev/null | head -c 2000)
+          \`\`\`
+          *Closed automatically by second AI gate. Re-trigger with \`/curator\` if needed.*" || true
+            gh pr close "$PR" --delete-branch || gh pr close "$PR" || echo "close failed"
+          else
+            echo "⚠️ Second AI: REQUEST_CHANGES → commenting, not merging/closing"
+            gh pr comment "$PR" --body "⚠️ **Second AI reviewer** (\`opencode/$REVIEW_MODEL\`) decision: **REQUEST_CHANGES**
+
+          - Not auto-merged. Please address \`curator-report.md\` notes (bilingual, star refresh, or minor fix).
+          - Log preview:
+          \`\`\`
+          $(head -n 60 "$SECOND_LOG" 2>/dev/null | head -c 2000)
+          \`\`\`
+          *Needs maintainer follow-up.*" || true
+            gh pr edit "$PR" --add-label "needs-review" || true
+          fi
+
+          echo "Second AI gate done."
 
       - name: Summary
         if: always()

--- a/.opencode/agent/reviewer.md
+++ b/.opencode/agent/reviewer.md
@@ -1,0 +1,39 @@
+---
+description: Second AI reviewer — independent gate for curator PRs, decides APPROVE/CLOSE
+mode: primary
+model: opencode/qwen3-coder-free
+temperature: 0.2
+permissions:
+  read: allow
+  grep: allow
+  glob: allow
+  bash: allow
+  webfetch: allow
+  websearch: allow
+  task: allow
+  todowrite: allow
+---
+
+You are the **Second AI Reviewer** for `awesome-deepseekharness/awesome-deepseek-harness`.
+
+**Goal:** Independently audit the PR created by the first AI curator (`curator`) and emit a strict DECISION. You are the gate that decides auto-merge vs auto-close. Never hallucinate — every claim needs `gh api`/`curl` or file evidence.
+
+**You have tools:** `read`/`grep`/`glob`, `bash` (`gh`, `curl`, `jq`), `webfetch`/`websearch`, `task`.
+
+**Input you will get in prompt:**
+- PR number, branch, and `curator-report.md` path (already on disk after `curate` job)
+- You must `read curator-report.md`, `read README.md` diff via `bash: git diff origin/main...HEAD -- README.md | head -n 120`, and sample-verify 1-2 star counts via `bash: gh api repos/owner/repo --jq .stargazers_count` if report claims drift.
+
+**Decision protocol — output exactly one line first:**
+```
+DECISION: APPROVE    # only if: bilingual ✅, no duplicates, curator opinion is Approve OR Needs discussion with star-refresh only (low risk), no broken links, report has Sources
+DECISION: CLOSE      # if: report says "no actionable findings" / "No PR/Issue — health audit only" with no patch, OR duplicate/invalid, OR preChecks show ❌ without fix
+DECISION: REQUEST_CHANGES  # minor fix needed (bilingual, title, star off by <10%, missing dsh-plugin) — do not merge/close, leave comment
+```
+Follow with 2-3 sentence rationale citing evidence (e.g., `curator-report.md: Repo Health`, `gh api` live stars). Also list `Sources:` you actually checked.
+
+**Guardrails:**
+- Do NOT edit files or push. Only produce log output; workflow step will parse `DECISION:` and run `gh pr merge` or `gh pr close`.
+- Prefer `gh api` for stars/topics, `read` for local files.
+- Be conservative: if uncertain, output `REQUEST_CHANGES`, not `APPROVE`.
+- Second AI must be independent — do not just echo first AI's `RECOMMEND:`; re-verify at least `curator-report.md` existence and one `gh api` call.


### PR DESCRIPTION
每3天巡检 + 第二AI自动审

**变更：**
- \curator.yml:5\ \cron: '17 2 * * *'\ → \'17 2 */3 * *'\ 每3天 02:17 UTC
- 新增 \.opencode/agent/reviewer.md\ 第二AI (\qwen3-coder-free\) 独立门控，输出 \DECISION: APPROVE/CLOSE/REQUEST_CHANGES\，职责：重读 \curator-report.md\、\git diff\、抽检 \gh api stars\
- workflow \curator.yml:183\ 新增 \Second AI review — auto merge or close\ 步骤：\if: steps.cpr.outputs.pull-request-number != ''\
  - \APPROVE\ → \gh pr review --approve\ + \gh pr merge --squash --delete-branch\ (被保护分支则留言待手动)
  - \CLOSE\ → \gh pr comment\ + \gh pr close --delete-branch\
  - \REQUEST_CHANGES\ → 仅评论 + \
eeds-review\
  - 有 \opencode\ 时跑 \opencode run --model opencode/qwen3-coder-free --agent reviewer\，无则回退 deterministic 解析 \RECOMMEND: Approve\/\
o actionable findings\

复用 \gh\ 查看：
\\\ash
gh pr view --json files
gh api repos/awesome-deepseekharness/awesome-deepseek-harness/contents/.github/workflows/curator.yml --jq .content | base64 -d | grep cron
cat .opencode/agent/reviewer.md
\\\

## Summary by Sourcery

Run curator inspections every three days and add an evidence-based second AI gate to manage resulting pull requests automatically.

New Features:
- Add an independent AI reviewer gate that evaluates curator pull requests and emits approve, close, or request-changes decisions.
- Automatically merge approved pull requests, close invalid or non-actionable pull requests, and label pull requests requiring maintainer changes.

Enhancements:
- Run curator inspections every three days instead of daily.
- Add conservative reviewer guidance requiring evidence-based checks of reports, diffs, links, duplicates, and reported star counts.

CI:
- Extend the curator workflow with optional OpenCode-based review and deterministic fallback decision handling.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reduces curator scheduling frequency and adds an AI-driven gate that can approve, merge, close, or label generated pull requests.
- Changes the curator cron schedule from daily to a day-of-month step expression.
- Adds a Qwen-based reviewer agent with repository, shell, and web access.
- Parses the reviewer output and performs privileged pull-request actions, with report-based fallback behavior.
</details>


<details open><summary><h3>Confidence Score: 0/5</h3></summary>

This PR is not safe to merge until the rejection override, incorrect PR-diff target, credential exposure boundary, and scheduling error are corrected.

The new gate can merge after an explicit request for changes, does not reliably inspect the generated PR branch, and runs an untrusted-content reviewer with repository and provider credentials; the schedule also produces irregular month-boundary intervals.

**Files Needing Attention:** .github/workflows/curator.yml and .opencode/agent/reviewer.md
</details>


<details open><summary><h3>Security Review</h3></summary>

The reviewer processes contributor-influenced report content while inheriting repository and provider credentials and having unrestricted shell/network access. This creates a prompt-injection path to credential disclosure, repository mutation, and manipulated merge authorization.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/curator.yml | Adds the automated review gate, but the fallback can override rejection, the audit targets the wrong Git ref, credentials cross an untrusted AI boundary, and the new cron does not provide a continuous three-day cadence. |
| .opencode/agent/reviewer.md | Defines the independent reviewer protocol, but grants shell and network access to an agent that consumes attacker-influenced content while the workflow supplies sensitive credentials. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Curator
    participant R as curator-report.md
    participant AI as Second AI reviewer
    participant P as Decision parser
    participant GH as GitHub PR
    C->>R: Generate report and recommendation
    R->>AI: Read report with inherited credentials
    AI-->>P: Emit decision log
    P->>R: Apply deterministic fallback
    alt APPROVE
        P->>GH: Approve and merge
    else CLOSE
        P->>GH: Comment and close
    else REQUEST_CHANGES
        P->>GH: Comment and label
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/curator.yml:250-253
**Rejection Is Overwritten**

When the second reviewer emits `DECISION: REQUEST_CHANGES` and the first curator's report contains `RECOMMEND: Approve`, this fallback replaces the independent rejection with `APPROVE`, causing the PR to be approved and passed to `gh pr merge`.

### Issue 2
.github/workflows/curator.yml:185-189
**Credentials Cross Untrusted AI Boundary**

When contributor-controlled issue or PR content reaches `curator-report.md`, the reviewer processes it with unrestricted shell and network tools while inheriting the repository token and three provider keys, enabling injected commands to disclose credentials or mutate the repository. **How this was verified:** The report is built from issue and PR metadata, and the changed reviewer consumes it with exported credentials plus Bash and web permissions.

### Issue 3
.github/workflows/curator.yml:198-199
**Audit Diffs Wrong Branch**

When `create-pull-request` creates the curator branch while the checkout remains on the triggering branch, fetching that branch without moving `HEAD` leaves both `git diff HEAD~1` and the prompted `git diff origin/main...HEAD` inspecting the checkout rather than the generated PR, causing the gate to approve or close without auditing the actual committed diff.

### Issue 4
.github/workflows/curator.yml:5
**Cron Resets Each Month**

The `*/3` day-of-month field restarts at day 1 each month rather than maintaining a three-day interval, causing irregular month-boundary runs such as August 31 followed by September 1.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(curator): every 3 days + second AI ..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/290a0887035e4674bd62c1dea78270e07b50cd2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58626384)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->