### PR TITLE
fix(gate): add workflow_run trigger for health PRs

### DIFF
--- a/.github/workflows/curator-gate.yml
+++ b/.github/workflows/curator-gate.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
     branches: [main]
+  workflow_run:
+    workflows: ["Curator — Health Audit (every 3 days)"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr:
@@ -22,13 +25,14 @@ concurrency:
 
 jobs:
   gate:
-    # Only for curator report PRs, or manual dispatch; independent retryable gate
+    # Only for curator report PRs, manual dispatch, or health workflow completion; independent retryable gate
     if: >
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         startsWith(github.head_ref, 'curator/report-')
-      )
+      ) ||
+      github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     timeout-minutes: 18
     steps:
@@ -42,8 +46,19 @@ jobs:
             echo "pr=${{ inputs.pr }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
             echo "pr=${{ github.event.number }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Health workflow just completed (via GITHUB_TOKEN, so pull_request_target didn't fire) — find newest open curator PR
+            echo "Triggered by workflow_run: ${{ github.event.workflow_run.name }} conclusion=${{ github.event.workflow_run.conclusion }}"
+            if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
+              echo "Health workflow failed — skip gate"
+              echo "pr=" >> $GITHUB_OUTPUT
+              cat $GITHUB_OUTPUT
+              exit 0
+            fi
+            PR=$(gh pr list --state open --search "head:curator/report-" --json number --jq 'sort_by(.createdAt) | reverse | .[0].number' || echo "")
+            echo "Resolved via workflow_run → pr=$PR"
+            echo "pr=$PR" >> $GITHUB_OUTPUT
           else
-            # fallback: try to find open curator PRs
             PR=$(gh pr list --state open --search "head:curator/report-" --json number --jq '.[0].number' || echo "")
             echo "pr=$PR" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Fix gate for GITHUB_TOKEN PRs: add workflow_run trigger for health audit completed, resolves newest curator/report-* PR. Keeps pull_request_target for human PRs and dispatch for manual retry. Verified via dispatch pr=68 -> REQUEST_CHANGES.

## Summary by Sourcery

Ensure curator health-audit pull requests reliably reach the gate regardless of how they are created.

Bug Fixes:
- Trigger the curator gate after successful health-audit workflow runs so GitHub-token-created health PRs are evaluated.

Enhancements:
- Retain support for human pull requests and manual retries while resolving the newest open curator report PR for workflow-run events.
- Skip gate evaluation when the health-audit workflow does not complete successfully.

CI:
- Add the health-audit workflow completion event as a curator gate trigger.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a `workflow_run` trigger so the curator gate runs after the periodic Health Audit completes.

- Skips gating when the upstream workflow does not succeed.
- Resolves an open curator report PR and feeds it into the existing review, merge, close, and labeling flow.
- The new resolver is not correlated with the triggering audit run and can act on a stale or unrelated PR.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until the workflow-run path is tied to the triggering audit's run-specific PR so it cannot mutate an unrelated report PR.

The new trigger can run after an audit that produced no PR and then approve, merge, close, or label an older open curator PR; its createdAt sort is also ineffective because that field is not requested.

**Files Needing Attention:** .github/workflows/curator-gate.yml
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/curator-gate.yml | Adds the desired completion trigger, but resolves a global open PR rather than the PR associated with the triggering workflow run. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant H as Health Audit
    participant G as Curator Gate
    participant API as GitHub PR API
    H->>G: workflow_run completed
    G->>API: "List all open curator/report-* PRs"
    API-->>G: Global matching PR list
    G->>G: Select an uncorrelated entry
    G->>API: Approve/merge, close, or label selected PR
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/curator-gate.yml:58
**Gate selects an unrelated PR**

When a successful Health Audit creates no PR while an older curator report PR remains open, this global query selects the older PR without correlating it to the triggering run, causing the gate to approve and merge, close, or label the wrong PR. With multiple open report PRs, `createdAt` is also absent from `--json`, so the query does not reliably select the newest PR and can leave the newly generated report ungated.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(gate): add workflow\_run trigger for ..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/7e7e1e85ac4c8260d2a59ccd9531e47d0a4d0fc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58631905)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->