### PR TITLE
Add dsh-qqbot-panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The hottest category — giving text-only models "eyes."
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
 | [zhengjy01/dsh-vercel-mcp](https://github.com/zhengjy01/dsh-vercel-mcp) | Vercel MCP connection for DSH: official OAuth 2.0 client flow against mcp.vercel.com; Vercel platform tools under mcp__vercel__* | 0 |
+| [dsh-qqbot-panel](https://github.com/zhengjy01/dsh-qqbot-panel) | Visual web settings panel for the official @tencent-connect/dsh-qqbot plugin (credentials, access modes/allowlists, workspace picker, scan-to-bind). | 0 |
 
 ### 📚 Skills
 


### PR DESCRIPTION
Add the dsh-qqbot-panel DSH plugin (visual settings panel for the official QQ bot plugin).

## Summary by Sourcery

New Features:
- Add dsh-qqbot-panel to the project’s plugin catalog as a visual web settings panel for the official QQ bot integration.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds dsh-qqbot-panel to the English Tools, Workflows & Presets catalog as a visual settings panel for the official QQ bot plugin.
- Adds the project link, feature description, and reported star count.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not ready to merge because the mandatory Chinese catalog entry is still missing.

The project is added only to README.md, while README.zh.md still lacks the corresponding row, leaving the bilingual catalog requirement unsatisfied.

**Files Needing Attention:** README.md and README.zh.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds one project entry to the English plugin catalog. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: empty commit to re-run aggregatio..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/ec786b5cbc21d7be7d27a6e57f9130d8300d3f4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58636516)</sub>

<!-- /greptile_comment -->