### PR TITLE
docs: add DSH-AutoKnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The hottest category — giving text-only models "eyes."
 | [xiufengsun/TokenTracker](https://github.com/xiufengsun/TokenTracker) | Local-first token & cost tracker for 31 coding tools incl. DSH, with native apps | 1315 |
 | [JingbiaoMei/Tokdash](https://github.com/JingbiaoMei/Tokdash) | Visualization & analytics for sessions and quota usage: heatmaps, cost tracking | 54 |
 | [EthanYoQ/Invoice-Downloader](https://github.com/EthanYoQ/Invoice-Downloader) | DSH bundle for local IMAP invoice download, OCR, archival, and Excel reimbursement summaries | 141 |
+| [Renjie-hub-byte/DSH-AutoKnit](https://github.com/Renjie-hub-byte/DSH-AutoKnit) | Divide-and-conquer PRD execution framework: PRD in, stable maintainable code out — programmatic scheduling (0 token), item-by-item auditor acceptance, recursive splitting; benchmarks show 16-41% cheaper with thicker deliveries | 0 |
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -179,6 +179,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [xiufengsun/TokenTracker](https://github.com/xiufengsun/TokenTracker) | 31 种编码工具的本地 token 与成本跟踪(含 DSH),有原生应用 | 1315 |
 | [JingbiaoMei/Tokdash](https://github.com/JingbiaoMei/Tokdash) | Sessions 与配额的可视化分析:热力图、成本追踪 | 54 |
 | [EthanYoQ/Invoice-Downloader](https://github.com/EthanYoQ/Invoice-Downloader) | 用于本地 IMAP 发票下载、OCR 识别、归档和 Excel 报销汇总的 DSH bundle | 141 |
+| [Renjie-hub-byte/DSH-AutoKnit](https://github.com/Renjie-hub-byte/DSH-AutoKnit) | 分治执行框架：PRD 进，稳定可维护的代码出——程序调度(0 token)、auditor 逐条采证验收、递归拆分；实测比同类省 16-41%，交付更厚 | 0 |
 
 ---
 


### PR DESCRIPTION
## What is this?

[DSH-AutoKnit](https://github.com/Renjie-hub-byte/DSH-AutoKnit) is a divide-and-conquer PRD execution framework built on dsh: planner / executor / auditor / recursive split. Programmatic scheduling (0 token), item-by-item auditor acceptance with a programmatic evidence layer, UCD upstream capability digests, human-in-the-loop escalation chain.

Benchmarked on the same PRD and model: 16% cheaper than lh-harness on a 3-module task, 41% cheaper on a ~7,000-line task (37 min), with thicker deliveries and 3x test density.

## Where

Added under **🚀 Apps & Runtimes Built on DSH** in both README.md and README.zh.md (bilingual entries).

Thanks for curating this list!

## Summary by Sourcery

Document DSH-AutoKnit as a DSH-based PRD execution framework in the bilingual project directories.

New Features:
- Add DSH-AutoKnit to the curated Apps & Runtimes Built on DSH listings.

Documentation:
- Document the DSH-AutoKnit project in both the English and Chinese README listings.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds DSH-AutoKnit to the curated applications and runtimes section in both English and Chinese.
- Adds matching bilingual project entries.
- Describes its divide-and-conquer PRD execution workflow and benchmark claims.
- Records the project with an initial star count of 0.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge, with no established actionable issues.

The two changed files add synchronized, correctly formatted bilingual table entries without altering executable behavior or breaking an established documentation contract.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds a correctly formatted English DSH-AutoKnit entry to the applications and runtimes table; no actionable defect was established. |
| README.zh.md | Adds the corresponding Chinese entry in the matching category; no actionable defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add DSH-AutoKnit"](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/87cb3668ca22ab7ecf7b6e38a6e255642f951840) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59085581)</sub>

<!-- /greptile_comment -->