### PR TITLE
Add hardes11/dsh-squeeze-command to Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The hottest category — giving text-only models "eyes."
 | [tinqiao-oss/engramory](https://github.com/tinqiao-oss/engramory) | Portable memory protocol for AI agents: load as standing rules, curation discipline + reference spec | 152 |
 | [text2future/flowix](https://github.com/text2future/flowix) | Notes for you, memory for your agents | 280 |
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | A unified agent memory workspace for human and agent | 131 |
+| [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | Manual budget-targeted context compression: the conversation model picks the ranges to summarize and a cheap flash-tier route writes the checkpoint summaries; `dsh plugin add dsh-squeeze-command` | 0 |
 
 ### 🎨 Web UI, Skins & Desktop Pets
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -86,6 +86,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [tinqiao-oss/engramory](https://github.com/tinqiao-oss/engramory) | 可移植的 agent 记忆协议:常驻规则加载、策展纪律 + 参考规范 | 152 |
 | [text2future/flowix](https://github.com/text2future/flowix) | 给你笔记、给 agent 记忆 | 280 |
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | 人与 agent 的统一记忆工作区 | 131 |
+| [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | 手动、面向预算的上下文压缩:对话模型圈定要总结的范围,廉价 flash 级路由生成检查点摘要;`dsh plugin add dsh-squeeze-command` | 0 |
 
 ### 🎨 Web UI、皮肤与桌面宠物
 


### PR DESCRIPTION
**Repo:** hardes11/dsh-squeeze-command
**Category:** Memory
**Stars:** 0 (verified via GitHub API; new release today)
**Language:** EN + ZH rows added (both files, same position)

**DSH relationship:** A DSH Cordis slash-command plugin (/squeeze) for the compaction seam — manual, budget-targeted context compression. The conversation model picks compressible ranges via a lazily-visible context_squeeze tool; a configured cheap flash-tier route writes the checkpoint summaries in parallel; commits follow the compaction capability's single-lock marker protocol.

**Verified install command:**
```
dsh plugin add dsh-squeeze-command
```
(verified on DSH with the headless profile; npm package dsh-squeeze-command@0.1.1 also installs standalone)

**Metadata:** MIT license; repo carries `dsh` and `dsh-plugin` topics; npm 0.1.1; release tag v0.1.1.

Checklist:
- [x] `dsh-plugin` GitHub topic present
- [x] LICENSE + README present
- [x] Release/tag exists (v0.1.1)
- [x] Title follows `Add owner/repo to Category`
- [x] Bilingual rows (README.md + README.zh.md, same category/position)
- [x] Star count verified (0)
- [x] No duplicate entry
- [x] One project per PR

## Summary by Sourcery

Add the dsh-squeeze-command plugin to the bilingual Memory project listings.

New Features:
- Add hardes11/dsh-squeeze-command to the Memory project directory as a manual, budget-targeted context compression plugin for DSH.

Documentation:
- Document the new project in both English and Chinese README listings, including its installation command and verified star count.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `hardes11/dsh-squeeze-command` to the Memory catalog in both supported languages.
- Adds matching English and Chinese entries at the same table position.
- Documents the plugin’s budget-targeted context compression behavior, installation command, and star count.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

The bilingual entries are aligned, correctly formatted, non-duplicative, and consistent with the repository’s catalog conventions and the verified metadata provided with the PR.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds a correctly formatted English Memory entry with no actionable issue identified. |
| README.zh.md | Adds the corresponding Chinese Memory entry at the matching catalog position with no actionable issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add hardes11/dsh-squeeze-command t..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/95324d4d4ac7713f8d76171c75d9c6c0761d6a05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59652831)</sub>

<!-- /greptile_comment -->