### PR TITLE
Add PerryLink/dsh-auto-review to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The hottest category — giving text-only models "eyes."
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
 | [zhengjy01/dsh-vercel-mcp](https://github.com/zhengjy01/dsh-vercel-mcp) | Vercel MCP connection for DSH: official OAuth 2.0 client flow against mcp.vercel.com; Vercel platform tools under mcp__vercel__* | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | Second-model approval for dsh: a read-only reviewer subagent returns structured allow/deny verdicts with reasons before actions run, fail-closed (`dsh plugin --profile web add dsh-auto-review`) | 130 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -143,6 +143,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
 | [zhengjy01/dsh-vercel-mcp](https://github.com/zhengjy01/dsh-vercel-mcp) | Vercel MCP 连接：官方 OAuth 2.0 流程对接 mcp.vercel.com，暴露 Vercel 平台工具 mcp__vercel__* | 0 |
+| [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | dsh 第二模型审批：只读评审子代理在动作执行前返回带理由的结构化 allow/deny 裁决，默认故障关闭（`dsh plugin --profile web add dsh-auto-review` 安装） | 130 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
- **Relation to DSH**: Approval-chain plugin for dsh: injects a read-only reviewer subagent that returns structured allow/deny verdicts with reasons before actions run (fail-closed by default).
- **Install**: dsh plugin --profile web add dsh-auto-review (npm: dsh-auto-review@0.10.1, verified published)
- **License**: Apache-2.0 · **Topic**: dsh-plugin ✓ · **Stars**: 130 (2026-09-03, gh api repos/PerryLink/dsh-auto-review --jq .stargazers_count)
- **Why here**: Tools/Workflows & Presets — an approval workflow gate.
- **No duplicate**: searched both READMEs for PerryLink/dsh-auto-review.

## Summary by Sourcery

Enhancements:
- Add dsh-auto-review to the English and Chinese tool directories as a fail-closed, second-model approval workflow for reviewing actions before execution.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds PerryLink/dsh-auto-review to the Tools, Workflows & Presets catalog in both supported languages.
- Documents the plugin’s read-only, fail-closed approval workflow.
- Includes the installation command and current star count.
- Keeps the English and Chinese listings aligned.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

The new English and Chinese entries are aligned, correctly formatted, non-duplicative, and introduce no accepted functional, security, or documentation-quality defect.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds a correctly formatted English catalog entry with no actionable issue identified. |
| README.zh.md | Adds the corresponding Chinese catalog entry at the matching location with no actionable issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add PerryLink/dsh-auto-review to Tools, ..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/5661096a04db8d411f369f60dbd4998f828c6230) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59831345)</sub>

<!-- /greptile_comment -->