### PR TITLE
Add PerryLink/dsh-ticktick to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The hottest category — giving text-only models "eyes."
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
 | [zhengjy01/dsh-vercel-mcp](https://github.com/zhengjy01/dsh-vercel-mcp) | Vercel MCP connection for DSH: official OAuth 2.0 client flow against mcp.vercel.com; Vercel platform tools under mcp__vercel__* | 0 |
+| [PerryLink/dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) | TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint | 0 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -143,6 +143,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
 | [zhengjy01/dsh-vercel-mcp](https://github.com/zhengjy01/dsh-vercel-mcp) | Vercel MCP 连接：官方 OAuth 2.0 流程对接 mcp.vercel.com，暴露 Vercel 平台工具 mcp__vercel__* | 0 |
+| [PerryLink/dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) | TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点 | 0 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
## Project / 项目

| Field | Value |
| --- | --- |
| **Repo** | `PerryLink/dsh-ticktick` → https://github.com/PerryLink/dsh-ticktick |
| **Category** | 🧩 Tools, Workflows & Presets |
| **Stars (verified)** | 0 (`gh api repos/PerryLink/dsh-ticktick --jq .stargazers_count`) |
| **Language (EN)** | TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint |
| **Language (ZH)** | TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点 |

## Relationship to DSH / 与 DSH 的关系

Cordis plugin (`cordis.patch.yml` + npm `@perrylink/dsh-ticktick`) that mounts a session-header task panel and agent tools over the official TickTick MCP endpoint; placed next to the TickTick-related dispatcher entry in Tools, Workflows & Presets.

## Install & Verification / 安装与验证

```bash
dsh plugin --profile web add @perrylink/dsh-ticktick
```

- [ ] 已本地验证安装成功 / Verified locally — not re-verified in this submission batch (honestly unchecked)
- [x] 仓库已打 `dsh-plugin` topic / `dsh-plugin` topic added
- [x] 含 LICENSE 与 README / Has LICENSE & README (Apache-2.0)
- [x] 已发布版本/Tag（3 tags / 2 releases；npm `@perrylink/dsh-ticktick` 0.1.2）

## Checklist / 检查清单

- [x] 标题符合 `Add owner/repo to Category`
- [x] `README.md` 和 `README.zh.md` 已同步添加一行（🧩 Tools, Workflows & Presets 表尾），格式 `| [owner/repo](link) | description | ⭐ |`
- [x] 星标数已核实（0）
- [x] 无重复条目（两份 README 中均无 `PerryLink/dsh-ticktick`）
- [x] 一个 PR 只添加一个项目

## Summary by Sourcery

Enhancements:
- Add the PerryLink/dsh-ticktick TickTick task bridge to the Tools, Workflows & Presets catalog in both English and Chinese README files.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds PerryLink/dsh-ticktick to the Tools, Workflows & Presets catalog in both language variants.
- Adds the English project link, description, and verified star count to `README.md`.
- Adds the corresponding Chinese entry to `README.zh.md`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

The two README changes are synchronized, correctly formatted, and introduce no observable runtime, build, or security failure.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds a correctly formatted English catalog entry for PerryLink/dsh-ticktick. |
| README.zh.md | Adds the synchronized Chinese catalog entry with matching link and star count. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add PerryLink/dsh-ticktick to Tools, Wor..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/c0487301c45606beb9e7a4794cd1aa6615623561) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60703514)</sub>

<!-- /greptile_comment -->