### PR TITLE
Add PerryLink/dsh-wechat to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The hottest category — giving text-only models "eyes."
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | Role-based model routing: planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash; ships a prompt section + `pro-flash-routing` skill | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | TickTick daily task dispatcher: interval pulls of todays due tasks, change-aware flomo+macOS notifications, optional auto-execute in headless sessions, worker workspace selection, web task board | 0 |
 | [zhengjy01/dsh-vercel-mcp](https://github.com/zhengjy01/dsh-vercel-mcp) | Vercel MCP connection for DSH: official OAuth 2.0 client flow against mcp.vercel.com; Vercel platform tools under mcp__vercel__* | 0 |
+| [PerryLink/dsh-wechat](https://github.com/PerryLink/dsh-wechat) | Bridges WeChat private messages to DSH with two-way text, image, file, and media transfer | 0 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -143,6 +143,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [thedeveloper256/dsh-model-router](https://github.com/thedeveloper256/dsh-model-router) | 基于角色的模型路由:规划者(根 agent)跑 deepseek-v4-pro,委派执行子 agent 跑 deepseek-v4-flash;附带 prompt 段与 `pro-flash-routing` 技能 | 1 |
 | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单每日任务分发器：定时拉取今日到期任务、变更感知 flomo+macOS 通知、可选无头会话自动执行、工作区选择、Web 任务看板 | 0 |
 | [zhengjy01/dsh-vercel-mcp](https://github.com/zhengjy01/dsh-vercel-mcp) | Vercel MCP 连接：官方 OAuth 2.0 流程对接 mcp.vercel.com，暴露 Vercel 平台工具 mcp__vercel__* | 0 |
+| [PerryLink/dsh-wechat](https://github.com/PerryLink/dsh-wechat) | 将微信私聊消息桥接到 DSH，支持文本、图片、文件与音视频双向传输 | 0 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
## Project / 项目

| Field | Value |
| --- | --- |
| **Repo** | `PerryLink/dsh-wechat` → https://github.com/PerryLink/dsh-wechat |
| **Category** | 🧩 Tools, Workflows & Presets |
| **Stars (verified)** | 0 (`gh api repos/PerryLink/dsh-wechat --jq .stargazers_count`) |
| **Language (EN)** | Bridges WeChat private messages to DSH with two-way text, image, file, and media transfer |
| **Language (ZH)** | 将微信私聊消息桥接到 DSH，支持文本、图片、文件与音视频双向传输 |

## Relationship to DSH / 与 DSH 的关系

Cordis plugin (`cordis.patch.yml` + npm `dsh-wechat`) that bridges WeChat private messages to DSH with two-way text, image, file and media transfer; filed under Tools, Workflows & Presets as a messaging-channel tool.

## Install & Verification / 安装与验证

```bash
dsh plugin --profile web add dsh-wechat
```

- [ ] 已本地验证安装成功 / Verified locally — not re-verified in this submission batch (honestly unchecked)
- [x] 仓库已打 `dsh-plugin` topic / `dsh-plugin` topic added
- [x] 含 LICENSE 与 README / Has LICENSE & README (MIT)
- [x] 已发布版本/Tag（5 tags；npm `dsh-wechat` 0.7.2）

## Checklist / 检查清单

- [x] 标题符合 `Add owner/repo to Category`
- [x] `README.md` 和 `README.zh.md` 已同步添加一行（🧩 Tools, Workflows & Presets 表尾），格式 `| [owner/repo](link) | description | ⭐ |`
- [x] 星标数已核实（0）
- [x] 无重复条目（两份 README 中均无 `PerryLink/dsh-wechat`）
- [x] 一个 PR 只添加一个项目

## Summary by Sourcery

Add dsh-wechat to the Tools, Workflows & Presets listings.

New Features:
- Add PerryLink/dsh-wechat to the Tools, Workflows & Presets catalog as a WeChat-to-DSH messaging bridge supporting bidirectional text, image, file, and media transfer.

Documentation:
- Document the new tool in both English and Chinese README catalogs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds PerryLink/dsh-wechat to the English and Chinese Tools, Workflows & Presets catalogs.
- Describes two-way WeChat private-message bridging for text, images, files, and media.
- Records the project with a star count of 0 in both listings.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the synchronized documentation entries follow the repository’s catalog conventions.

Both README files add the same repository in the corresponding category using valid table formatting and consistent translated descriptions, with no concrete blocking or non-blocking defect identified.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds a correctly formatted English catalog entry under Tools, Workflows & Presets with no identified issue. |
| README.zh.md | Adds the corresponding Chinese catalog entry in the same category with no identified issue. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add PerryLink/dsh-wechat to Tools, Workf..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/47b419b01d1d617c4d7b83f95c850484f3b28068) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60703598)</sub>

<!-- /greptile_comment -->