### PR TITLE
Add SuperJJ007/papermachine to Apps & Runtimes Built on DSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ The hottest category — giving text-only models "eyes."
 | [JingbiaoMei/Tokdash](https://github.com/JingbiaoMei/Tokdash) | Visualization & analytics for sessions and quota usage: heatmaps, cost tracking | 54 |
 | [EthanYoQ/Invoice-Downloader](https://github.com/EthanYoQ/Invoice-Downloader) | DSH bundle for local IMAP invoice download, OCR, archival, and Excel reimbursement summaries | 141 |
 | [Renjie-hub-byte/DSH-AutoKnit](https://github.com/Renjie-hub-byte/DSH-AutoKnit) | Divide-and-conquer PRD execution framework: PRD in, stable maintainable code out — programmatic scheduling (0 token), item-by-item auditor acceptance, recursive splitting; benchmarks show 16-41% cheaper with thicker deliveries | 0 |
+| [SuperJJ007/papermachine](https://github.com/SuperJJ007/papermachine) | Desktop data-analysis app built on DeepSeek Harness, running local Python and R with inspectable execution steps and chart/table provenance. | 48 |
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -201,6 +201,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [JingbiaoMei/Tokdash](https://github.com/JingbiaoMei/Tokdash) | Sessions 与配额的可视化分析:热力图、成本追踪 | 54 |
 | [EthanYoQ/Invoice-Downloader](https://github.com/EthanYoQ/Invoice-Downloader) | 用于本地 IMAP 发票下载、OCR 识别、归档和 Excel 报销汇总的 DSH bundle | 141 |
 | [Renjie-hub-byte/DSH-AutoKnit](https://github.com/Renjie-hub-byte/DSH-AutoKnit) | 分治执行框架：PRD 进，稳定可维护的代码出——程序调度(0 token)、auditor 逐条采证验收、递归拆分；实测比同类省 16-41%，交付更厚 | 0 |
+| [SuperJJ007/papermachine](https://github.com/SuperJJ007/papermachine) | 基于 DeepSeek Harness 的桌面数据分析应用，在本机运行 Python 和 R，支持检查执行步骤及追溯图表和表格的来源。 | 48 |
 
 ---
 


### PR DESCRIPTION
## Project

Add **SuperJJ007/papermachine** to **Apps & Runtimes Built on DSH** in both READMEs. GitHub stars: **48**, checked on 2026-09-09.

## Relationship to DSH and installation

PaperMachine is a desktop data-analysis application assembled from DeepSeek Harness plugins. It runs Python and R locally, exposes execution steps, and links figures and tables to their producing code, execution log, messages, and environment.

- Repository: https://github.com/SuperJJ007/papermachine
- Release: [papermachine-v0.1.1](https://github.com/SuperJJ007/papermachine/releases/tag/papermachine-v0.1.1)
- Installation: download the macOS Apple silicon / Intel DMG or experimental Windows x64 installer from the release page. First launch installs the Python/R environment; users supply their own DeepSeek API key. See [Quick start](https://github.com/SuperJJ007/papermachine#quick-start).
- License: MIT. The repository has the `dsh-plugin` topic.
- Verification: checked the public README, release assets, license and GitHub metadata; no fresh desktop installation or live model analysis was run for this directory submission.
- This is an early desktop application release; Windows is experimental/beta.

![PaperMachine desktop](https://raw.githubusercontent.com/SuperJJ007/papermachine/main/docs/media/hero.png)

[Execution trace demo](https://github.com/SuperJJ007/papermachine/blob/main/docs/media/trace.gif) · [Artifact provenance demo](https://github.com/SuperJJ007/papermachine/blob/main/docs/media/artifact.gif)

## Checklist

- [x] Added one row to both READMEs in the same category.
- [x] Verified repository, release assets, MIT license, and `dsh-plugin` topic.
- [x] Checked the current star count.
- [x] Checked for duplicate entries and existing PaperMachine PRs.
- [x] One project in this PR; `git diff --check` passes.
- [ ] Fresh local installation verification (not performed for this submission).

## Summary by Sourcery

New Features:
- Add PaperMachine to the English and Chinese catalogs of apps and runtimes built on DSH.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61996049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/deef/-/pull-requests/awesome-deepseekharness/awesome-deepseek-harness/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge after the non-blocking star-count snapshot date inconsistency is corrected.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Star snapshot date mismatch** <a href="https://github.com/awesome-deepseekharness/awesome-deepseek-harness/pull/87#discussion_r3965816062">▶</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:203
This row uses a star count checked on 2026-09-09, while the README footer says all counts are current as of 2026-08-15, making the documented snapshot internally inconsistent in both README variants.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds matching bilingual project links, descriptions, and a 48-star count.
- Keeps the project in the same category in both README variants.
</details>

<!-- /greptile_comment -->