### PR TITLE
Add laodonge/col-dsh-plugin to Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The hottest category — giving text-only models "eyes."
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | A unified agent memory workspace for human and agent | 131 |
 | [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | Manual budget-targeted context compression: the conversation model picks the ranges to summarize and a cheap flash-tier route writes the checkpoint summaries; `dsh plugin add dsh-squeeze-command` | 0 |
 | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | Bounded, layered, approval-gated cross-session memory for dsh with frozen snapshot injection (`dsh plugin --profile web add dsh-memento`) | 85 |
-
 | [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | Context Organization Layer for DSH/Cordis: `ctx.col` provides persistent organizational Contexts with replaceable executors — verified 3-tier write-back, audited history, model-callable `col.create_context`. Zero deps besides peer `@deepseek-ai/cordis`. | |
 ### 🎨 Web UI, Skins & Desktop Pets
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ DeepSeek Harness is DeepSeek AI's open-source agent harness. Its core philosophy
 ---
 
 ## 📦 Plugins (The Core)
+- [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) — Context Organization Layer for DSH/Cordis: `ctx.col` provides persistent organizational Contexts with replaceable executors (verified 3-tier write-back, audited history, model-callable `col.create_context` tool). Zero deps besides peer `@deepseek-ai/cordis`.
 
 > Publishing your own plugin? Tag your repository with the [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic for discoverability.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ DeepSeek Harness is DeepSeek AI's open-source agent harness. Its core philosophy
 ---
 
 ## 📦 Plugins (The Core)
-- [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) — Context Organization Layer for DSH/Cordis: `ctx.col` provides persistent organizational Contexts with replaceable executors (verified 3-tier write-back, audited history, model-callable `col.create_context` tool). Zero deps besides peer `@deepseek-ai/cordis`.
 
 > Publishing your own plugin? Tag your repository with the [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic for discoverability.
 
@@ -94,6 +93,7 @@ The hottest category — giving text-only models "eyes."
 | [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | Manual budget-targeted context compression: the conversation model picks the ranges to summarize and a cheap flash-tier route writes the checkpoint summaries; `dsh plugin add dsh-squeeze-command` | 0 |
 | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | Bounded, layered, approval-gated cross-session memory for dsh with frozen snapshot injection (`dsh plugin --profile web add dsh-memento`) | 85 |
 
+| [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | Context Organization Layer for DSH/Cordis: `ctx.col` provides persistent organizational Contexts with replaceable executors — verified 3-tier write-back, audited history, model-callable `col.create_context`. Zero deps besides peer `@deepseek-ai/cordis`. | |
 ### 🎨 Web UI, Skins & Desktop Pets
 
 | Project | Description | ⭐ |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The hottest category — giving text-only models "eyes."
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | A unified agent memory workspace for human and agent | 131 |
 | [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | Manual budget-targeted context compression: the conversation model picks the ranges to summarize and a cheap flash-tier route writes the checkpoint summaries; `dsh plugin add dsh-squeeze-command` | 0 |
 | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | Bounded, layered, approval-gated cross-session memory for dsh with frozen snapshot injection (`dsh plugin --profile web add dsh-memento`) | 85 |
-| [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | Context Organization Layer for DSH/Cordis: `ctx.col` provides persistent organizational Contexts with replaceable executors — verified 3-tier write-back, audited history, model-callable `col.create_context`. Zero deps besides peer `@deepseek-ai/cordis`. | 0 |
+| [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | Context Organization Layer for DSH/Cordis: `ctx.col` provides persistent organizational Contexts with replaceable executors — verified 3-tier write-back, audited history, model-callable `col.create_context`. Zero deps besides peer `@deepseek-ai/cordis`. Install: npm i col-dsh-plugin. | 0 |
 ### 🎨 Web UI, Skins & Desktop Pets
 
 | Project | Description | ⭐ |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The hottest category — giving text-only models "eyes."
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | A unified agent memory workspace for human and agent | 131 |
 | [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | Manual budget-targeted context compression: the conversation model picks the ranges to summarize and a cheap flash-tier route writes the checkpoint summaries; `dsh plugin add dsh-squeeze-command` | 0 |
 | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | Bounded, layered, approval-gated cross-session memory for dsh with frozen snapshot injection (`dsh plugin --profile web add dsh-memento`) | 85 |
-| [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | Context Organization Layer for DSH/Cordis: `ctx.col` provides persistent organizational Contexts with replaceable executors — verified 3-tier write-back, audited history, model-callable `col.create_context`. Zero deps besides peer `@deepseek-ai/cordis`. | |
+| [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | Context Organization Layer for DSH/Cordis: `ctx.col` provides persistent organizational Contexts with replaceable executors — verified 3-tier write-back, audited history, model-callable `col.create_context`. Zero deps besides peer `@deepseek-ai/cordis`. | 0 |
 ### 🎨 Web UI, Skins & Desktop Pets
 
 | Project | Description | ⭐ |

--- a/README.zh.md
+++ b/README.zh.md
@@ -92,7 +92,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | 人与 agent 的统一记忆工作区 | 131 |
 | [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | 手动、面向预算的上下文压缩:对话模型圈定要总结的范围,廉价 flash 级路由生成检查点摘要;`dsh plugin add dsh-squeeze-command` | 0 |
 | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | dsh 有界分层、审批门控、可审计的跨会话记忆，支持冻结快照注入（`dsh plugin --profile web add dsh-memento` 安装） | 85 |
-| [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | 为 DSH/Cordis 提供 Context Organization Layer：`ctx.col` 提供持久的组织化 Context（职位）、可替换执行器、验证过的三层写回与可审计历史，并提供可被模型调用的 `col.create_context` 工具。除 peer 依赖 `@deepseek-ai/cordis` 外零依赖。 | 0 |
+| [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | 为 DSH/Cordis 提供 Context Organization Layer：`ctx.col` 提供持久的组织化 Context（职位）、可替换执行器、验证过的三层写回与可审计历史，并提供可被模型调用的 `col.create_context` 工具。除 peer 依赖 `@deepseek-ai/cordis` 外零依赖。安装：npm i col-dsh-plugin. | 0 |
 
 ### 🎨 Web UI、皮肤与桌面宠物
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -92,6 +92,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | 人与 agent 的统一记忆工作区 | 131 |
 | [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | 手动、面向预算的上下文压缩:对话模型圈定要总结的范围,廉价 flash 级路由生成检查点摘要;`dsh plugin add dsh-squeeze-command` | 0 |
 | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | dsh 有界分层、审批门控、可审计的跨会话记忆，支持冻结快照注入（`dsh plugin --profile web add dsh-memento` 安装） | 85 |
+| [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | 为 DSH/Cordis 提供 Context Organization Layer：`ctx.col` 提供持久的组织化 Context（职位）、可替换执行器、验证过的三层写回与可审计历史，并提供可被模型调用的 `col.create_context` 工具。除 peer 依赖 `@deepseek-ai/cordis` 外零依赖。 | |
 
 ### 🎨 Web UI、皮肤与桌面宠物
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -92,7 +92,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | 人与 agent 的统一记忆工作区 | 131 |
 | [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | 手动、面向预算的上下文压缩:对话模型圈定要总结的范围,廉价 flash 级路由生成检查点摘要;`dsh plugin add dsh-squeeze-command` | 0 |
 | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | dsh 有界分层、审批门控、可审计的跨会话记忆，支持冻结快照注入（`dsh plugin --profile web add dsh-memento` 安装） | 85 |
-| [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | 为 DSH/Cordis 提供 Context Organization Layer：`ctx.col` 提供持久的组织化 Context（职位）、可替换执行器、验证过的三层写回与可审计历史，并提供可被模型调用的 `col.create_context` 工具。除 peer 依赖 `@deepseek-ai/cordis` 外零依赖。 | |
+| [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) | 为 DSH/Cordis 提供 Context Organization Layer：`ctx.col` 提供持久的组织化 Context（职位）、可替换执行器、验证过的三层写回与可审计历史，并提供可被模型调用的 `col.create_context` 工具。除 peer 依赖 `@deepseek-ai/cordis` 外零依赖。 | 0 |
 
 ### 🎨 Web UI、皮肤与桌面宠物
 


### PR DESCRIPTION
Adds [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin): persistent organizational Contexts (`ctx.col`), replaceable executors, verified 3-tier write-back, audited history, model-callable tool. Real-load verified on DSH (see repo LAB-EVIDENCE). MIT, peer dep `@deepseek-ai/cordis` only.

## Summary by Sourcery

Documentation:
- Document the laodonge/col-dsh-plugin project in the English and Chinese plugin listings, including its capabilities, dependency, installation command, and star count.









<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62143532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/deef/-/pull-requests/awesome-deepseekharness/awesome-deepseek-harness/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Adds the plugin’s capabilities, dependency information, installation command, and star count to `README.md`.
- Adds the corresponding localized entry to `README.zh.md`.
</details>

<!-- /greptile_comment -->