### PR TITLE
Add vbarter/dsh-plugin-registry to Marketplaces & Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ DeepSeek Harness is DeepSeek AI's open-source agent harness. Its core philosophy
 | [Nagi-ovo/dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) | A DSH skill that finds, installs, and verifies GitHub plugins | 78 |
 | [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | Radar index repo that auto-scans dsh plugin candidates | 908 |
 | [LaplaceYoung/oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | 700+ plugins registered only through extension seams — no agent-loop modification | 45 |
+| [vbarter/dsh-plugin-registry](https://dsplugin.app/) | Unofficial community DeepSeek Harness plugin directory / dsh plugin registry — browse & publish with Manifest / `dsh.bundle` checks ([GitHub](https://github.com/vbarter/dsh-plugin-registry)) | 0 |
 
 ### 👁️ Vision
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -55,6 +55,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [Nagi-ovo/dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) | 帮 DSH 搜索、安装并验证插件的 Skill | 78 |
 | [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 自动扫描 dsh 插件候选的前部索引仓库(Radar) | 908 |
 | [LaplaceYoung/oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | 700+ 插件,只通过扩展接缝注册,不改 agent-loop 骨架 | 45 |
+| [vbarter/dsh-plugin-registry](https://dsplugin.app/) | 非官方社区 DeepSeek Harness 插件目录 / dsh 插件注册表 — 浏览与发布，含 Manifest / `dsh.bundle` 校验（[GitHub](https://github.com/vbarter/dsh-plugin-registry)） | 0 |
 
 ### 👁️ 视觉插件
 


### PR DESCRIPTION
## Project / 项目

| Field | Value |
| --- | --- |
| **Repo** | `vbarter/dsh-plugin-registry` → https://github.com/vbarter/dsh-plugin-registry |
| **Site** | https://dsplugin.app/ |
| **Category** | 🛍️ Marketplaces & Discovery / 插件市场与发现 |
| **Stars (verified)** | 0 |
| **Language (EN)** | Unofficial community DeepSeek Harness plugin directory / dsh plugin registry — browse & publish with Manifest / `dsh.bundle` checks |
| **Language (ZH)** | 非官方社区 DeepSeek Harness 插件目录 / dsh 插件注册表 — 浏览与发布，含 Manifest / `dsh.bundle` 校验 |

> ⚠️ **Bilingual required / 双语必填**：已同时更新 `README.md` **和** `README.zh.md` 同一分类同一位置。

## Relationship to DSH / 与 DSH 的关系

Community (unofficial) discovery site for DeepSeek Harness plugins. Indexes `dsh-plugin` topic repos, checks Manifest / `dsh.bundle`, and lets authors publish via GitHub Issue → PR. Fits **Marketplaces & Discovery**.

社区（非官方）DSH 插件发现站：收录 `dsh-plugin` topic、校验 Manifest / `dsh.bundle`，作者可通过 Issue → PR 发布。归属 **插件市场与发现**。

## Install & Verification / 安装与验证

This entry is a **marketplace / discovery directory** (website), not an installable dsh plugin.

```bash
# Browse the registry
open https://dsplugin.app/
# Source
https://github.com/vbarter/dsh-plugin-registry
```

- [x] Site publicly accessible / 站点可公开访问
- [x] Source has LICENSE & README / 源码含 LICENSE 与 README
- [ ] N/A — not a `dsh plugin add` package (directory site)
- [ ] N/A — `dsh-plugin` topic applies to plugin repos; this is the registry itself

## Checklist / 检查清单

- [x] 标题符合 `Add vbarter/dsh-plugin-registry to Marketplaces & Discovery`
- [x] `README.md` 和 `README.zh.md` 已同步添加一行，位置正确
- [x] 星标数已核实（0）
- [x] 无重复条目
- [x] 一个 PR 只添加一个项目

## Additional Notes / 备注

Primary link points to https://dsplugin.app/ (homepage). Unofficial community directory — not affiliated with DeepSeek AI.

## Summary by Sourcery

Add the community DeepSeek Harness plugin registry to the Marketplaces & Discovery catalog.

New Features:
- Add the vbarter/dsh-plugin-registry community directory to the Marketplaces & Discovery listings in both English and Chinese READMEs.

Documentation:
- Document the registry’s website, GitHub source, and Manifest/`dsh.bundle` verification capabilities in the project listings.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62520687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, though both new rows should link the project name directly to its GitHub repository to match the documented listing convention.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Project link breaks listing convention** <a href="https://github.com/awesome-deepseekharness/awesome-deepseek-harness/pull/90#discussion_r3977527213">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
README.md:58
The project-name link opens `https://dsplugin.app/` instead of the named GitHub repository, contrary to the documented row format and every sibling marketplace entry. Update the first-column link in both language files so readers clicking the repository name reach its source repository.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details open><summary><h3>Summary</h3></summary>

- Adds a homepage, source-repository link, description, and star count to `README.md`.
- Adds the corresponding localized entry to `README.zh.md`.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Add vbarter/dsh-plugin-registry to Marke..."](https://github.com/awesome-deepseekharness/awesome-deepseek-harness/commit/c314c3e779649873f63fd6c6741ce233f65833e6)</sub>

<!-- /greptile_comment -->