### PR TITLE
Add 7 zhengjy01 dsh plugins to Tools, Workflows & Presets (zsxq, skill-recommender, goofish-mcp, npm, backup-migrator, feishu-mcp, aliyun-mcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ The hottest category — giving text-only models "eyes."
 | [PerryLink/dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) | TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint | 0 |
 | [PerryLink/dsh-wechat](https://github.com/PerryLink/dsh-wechat) | Bridges WeChat private messages to DSH with two-way text, image, file, and media transfer | 0 |
 | [zhengjy01/dsh-qqbot-panel](https://github.com/zhengjy01/dsh-qqbot-panel) | Visual web settings panel for the official @tencent-connect/dsh-qqbot plugin (credentials, access modes/allowlists, workspace picker, scan-to-bind). | 0 |
+| [zhengjy01/dsh-zsxq](https://github.com/zhengjy01/dsh-zsxq) | Knowledge Planet (知识星球 zsxq) integration for DSH: cookie/QR login against the unofficial web API, agent tools for groups / topic lists / topic detail / search / publish / comment / like, plus a web settings panel. | 0 |
+| [zhengjy01/dsh-skill-recommender](https://github.com/zhengjy01/dsh-skill-recommender) | Session-profile driven open-source skill recommender for DSH: scans local DSH / Codex / Claude sessions, builds a weighted profile (topics, tools, tasks, projects) and recommends matching skills with a tunable match index. | 0 |
+| [zhengjy01/dsh-goofish-mcp](https://github.com/zhengjy01/dsh-goofish-mcp) | Xianyu (Goofish 闲鱼) read-only monitoring for DSH: drives the goofish-cli MCP server and exposes read-only tools (search, item detail, listings, chat history, category) with all write actions filtered out. | 0 |
+| [zhengjy01/dsh-npm](https://github.com/zhengjy01/dsh-npm) | NPM registry management for DSH: query package info, list versions, search packages, and publish/deprecate with optional token injection, plus a web settings panel. | 0 |
+| [zhengjy01/dsh-backup-migrator](https://github.com/zhengjy01/dsh-backup-migrator) | Plugin environment backup and migration for DSH: backs up every profile's plugin list, plugin configs and local-source plugin tarballs into a git repo, and restores them on a new machine. | 0 |
+| [zhengjy01/dsh-feishu-mcp](https://github.com/zhengjy01/dsh-feishu-mcp) | Feishu (Lark) OpenAPI MCP connection for DSH: bridges the official @larksuiteoapi/lark-mcp server, exposing IM, Bitable, Docs, Calendar and Drive APIs as mcp__feishu__* tools with OAuth user-token support. | 0 |
+| [zhengjy01/dsh-aliyun-mcp](https://github.com/zhengjy01/dsh-aliyun-mcp) | Alibaba Cloud OpenAPI MCP connection for DSH: static-credential mode through the official OpenAPI MCP proxy, exposing ECS / OSS / DNS / Function Compute APIs as mcp__aliyun__* tools. | 0 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -164,6 +164,13 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [PerryLink/dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) | TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点 | 0 |
 | [PerryLink/dsh-wechat](https://github.com/PerryLink/dsh-wechat) | 将微信私聊消息桥接到 DSH，支持文本、图片、文件与音视频双向传输 | 0 |
 | [zhengjy01/dsh-qqbot-panel](https://github.com/zhengjy01/dsh-qqbot-panel) | 官方 @tencent-connect/dsh-qqbot 插件的可视化 Web 设置面板（凭据、访问模式/白名单、工作区选择、扫码绑定）。 | 0 |
+| [zhengjy01/dsh-zsxq](https://github.com/zhengjy01/dsh-zsxq) | 知识星球（zsxq）集成：基于非官方 Web API 的 Cookie / 扫码登录，提供星球列表、主题列表、主题详情、搜索、发布、评论、点赞等 agent 工具，附 Web 设置面板。 | 0 |
+| [zhengjy01/dsh-skill-recommender](https://github.com/zhengjy01/dsh-skill-recommender) | 会话画像驱动的开源 skill 推荐器：扫描本地 DSH / Codex / Claude 会话，构建加权画像（主题 / 工具 / 任务 / 项目），按可调匹配指数推荐合适的 skill。 | 0 |
+| [zhengjy01/dsh-goofish-mcp](https://github.com/zhengjy01/dsh-goofish-mcp) | 闲鱼（Goofish）只读监控：驱动 goofish-cli MCP 服务器，暴露搜索、商品详情、在售列表、会话历史、类目识别等只读工具，写操作全部过滤。 | 0 |
+| [zhengjy01/dsh-npm](https://github.com/zhengjy01/dsh-npm) | npm registry 管理：查询包信息、列出全部版本、搜索包，以及带可选 token 注入的 publish / deprecate，附 Web 设置面板。 | 0 |
+| [zhengjy01/dsh-backup-migrator](https://github.com/zhengjy01/dsh-backup-migrator) | 插件环境备份与迁移：把各 profile 的插件清单、插件配置与本地源插件 tgz 打包备份进 git 仓库，换新机器一键还原。 | 0 |
+| [zhengjy01/dsh-feishu-mcp](https://github.com/zhengjy01/dsh-feishu-mcp) | 飞书（Lark）OpenAPI MCP 连接：桥接官方 @larksuiteoapi/lark-mcp，以 mcp__feishu__* 暴露 IM、多维表格、云文档、日历、云盘 API，支持 OAuth 用户令牌。 | 0 |
+| [zhengjy01/dsh-aliyun-mcp](https://github.com/zhengjy01/dsh-aliyun-mcp) | 阿里云 OpenAPI MCP 连接：通过官方 OpenAPI MCP 代理的静态凭据模式，以 mcp__aliyun__* 暴露 ECS / OSS / DNS / 函数计算等 API。 | 0 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
## 说明

将 `zhengjy01` 的 7 个新 DSH 插件按现有表格追加到 **🧩 Tools, Workflows & Presets** 分类（与已收录的 `dsh-wps` / `dsh-task-dispatcher` / `dsh-vercel-mcp` / `dsh-qqbot-panel` 同区块），仅追加 7 行，未改动或重排任何已有条目。

## 新增插件（仓库 / npm 包名）

| 仓库 | npm 包 | 用途 |
| --- | --- | --- |
| [`zhengjy01/dsh-zsxq`](https://github.com/zhengjy01/dsh-zsxq) | `dsh-zsxq` | 知识星球（zsxq）集成：基于非官方 web API 的 Cookie / 扫码登录，提供星球列表、主题列表、主题详情、搜索、发布、评论、点赞等 agent 工具与 Web 设置面板 |
| [`zhengjy01/dsh-skill-recommender`](https://github.com/zhengjy01/dsh-skill-recommender) | `dsh-skill-recommender` | 会话画像驱动的开源 skill 推荐器：扫描本地 DSH / Codex / Claude 会话，构建加权画像（主题 / 工具 / 任务 / 项目）并按可调匹配指数推荐 skill |
| [`zhengjy01/dsh-goofish-mcp`](https://github.com/zhengjy01/dsh-goofish-mcp) | `dsh-goofish-mcp` | 闲鱼（Goofish）只读监控：驱动 goofish-cli MCP 服务器，暴露搜索 / 商品详情 / 在售列表 / 会话历史 / 类目等只读工具，写操作全部过滤 |
| [`zhengjy01/dsh-npm`](https://github.com/zhengjy01/dsh-npm) | `dsh-npm` | npm registry 管理：查询包信息、列版本、搜索包，以及带可选 token 注入的 publish / deprecate，附 Web 设置面板 |
| [`zhengjy01/dsh-backup-migrator`](https://github.com/zhengjy01/dsh-backup-migrator) | `dsh-backup-migrator` | 插件环境备份与迁移：把各 profile 的插件清单、插件配置与本地源插件 tgz 备份进 git 仓库，换机一键还原 |
| [`zhengjy01/dsh-feishu-mcp`](https://github.com/zhengjy01/dsh-feishu-mcp) | `dsh-feishu-mcp` | 飞书（Lark）OpenAPI MCP 连接：桥接官方 `@larksuiteoapi/lark-mcp`，以 `mcp__feishu__*` 暴露 IM / 多维表格 / 云文档 / 日历 / 云盘 API，支持 OAuth 用户令牌 |
| [`zhengjy01/dsh-aliyun-mcp`](https://github.com/zhengjy01/dsh-aliyun-mcp) | `dsh-aliyun-mcp` | 阿里云 OpenAPI MCP 连接：通过官方 OpenAPI MCP 代理的静态凭据模式，以 `mcp__aliyun__*` 暴露 ECS / OSS / DNS / 函数计算 API |

## 与 DSH 的关系

7 个仓库均为 DSH 插件（已打 `dsh-plugin` topic、发布到 npm，可用 `dsh plugin --profile web add <包名>` 安装），其中 4 个为官方 MCP 服务器/OpenAPI 的连接器，3 个为插件环境与内容平台管理工具。

## 变更范围

- `README.md`：在「🧩 Tools, Workflows & Presets」表末尾追加 7 行（`grep -c zhengjy01 README.md`：4 → 11）。
- `README.zh.md`：在「🧩 工具、工作流与预设」表末尾追加对应的 7 行中文说明，位置与英文一一对应（`grep -c zhengjy01 README.zh.md`：4 → 11）。
- 合计 +14/-0，未改动或重排任何已有条目。

## Summary by Sourcery

Add seven zhengjy01 DSH plugins to the English and Chinese Tools, Workflows & Presets catalogs.

New Features:
- Add seven zhengjy01 DSH plugins to the English Tools, Workflows & Presets catalog, covering platform integrations, skill recommendations, package management, backup migration, and MCP connectors.
- Add matching Chinese catalog entries for all seven plugins.

Documentation:
- Expand the English and Chinese README plugin catalogs with descriptions and links for the seven new DSH plugins.