### PR TITLE
Add PerryLink/dsh-background-agents to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The hottest category — giving text-only models "eyes."
 | [PerryLink/dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) | TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint | 0 |
 | [PerryLink/dsh-wechat](https://github.com/PerryLink/dsh-wechat) | Bridges WeChat private messages to DSH with two-way text, image, file, and media transfer | 0 |
 | [zhengjy01/dsh-qqbot-panel](https://github.com/zhengjy01/dsh-qqbot-panel) | Visual web settings panel for the official @tencent-connect/dsh-qqbot plugin (credentials, access modes/allowlists, workspace picker, scan-to-bind). | 0 |
+| [PerryLink/dsh-background-agents](https://github.com/PerryLink/dsh-background-agents) | Durable background child agents on the official subagent seam with a Web sidebar, messaging and interrupt (`dsh plugin --profile web add dsh-background-agents`) | 12 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -164,6 +164,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [PerryLink/dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) | TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点 | 0 |
 | [PerryLink/dsh-wechat](https://github.com/PerryLink/dsh-wechat) | 将微信私聊消息桥接到 DSH，支持文本、图片、文件与音视频双向传输 | 0 |
 | [zhengjy01/dsh-qqbot-panel](https://github.com/zhengjy01/dsh-qqbot-panel) | 官方 @tencent-connect/dsh-qqbot 插件的可视化 Web 设置面板（凭据、访问模式/白名单、工作区选择、扫码绑定）。 | 0 |
+| [PerryLink/dsh-background-agents](https://github.com/PerryLink/dsh-background-agents) | 官方子代理接缝上的持久后台子代理：Web 侧边栏看进度、随时留言与打断（`dsh plugin --profile web add dsh-background-agents` 安装） | 12 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
## Project / 项目

| Field | Value |
| --- | --- |
| **Repo** | `PerryLink/dsh-background-agents` → https://github.com/PerryLink/dsh-background-agents |
| **Category** | 🧩 Tools, Workflows & Presets |
| **Stars (verified)** | 12（2026-09-13 gh api repos/PerryLink/dsh-background-agents stargazers_count 实测） |
| **Language (EN)** | Durable background child agents on the official subagent seam with a Web sidebar, messaging and interrupt (`dsh plugin --profile web add dsh-background-agents`) |
| **Language (ZH)** | 官方子代理接缝上的持久后台子代理：Web 侧边栏看进度、随时留言与打断（`dsh plugin --profile web add dsh-background-agents` 安装） |

> ⚠️ **Bilingual required / 双语必填**：本 PR 同时更新 `README.md` 与 `README.zh.md` 同一分类的同一位置。

## Relationship to DSH / 与 DSH 的关系

DSH plugin: package.json declares the dsh.bundle manifest ("dsh": {"bundle": {"patch": "./cordis.patch.yml"}}) with cordis.patch.yml shipped in the repo; installed via the command in the description; the repository carries the dsh-plugin topic.

## Install & Verification / 安装与验证

```bash
dsh plugin --profile web add dsh-background-agents
```

- [x] 已本地验证安装成功 / Verified locally
- [x] 仓库已打 `dsh-plugin` topic（2026-09-13 live 复核）
- [x] 含 LICENSE 与 README / Has LICENSE & README（Apache-2.0）
- [x] 已发布版本 Tag / Has release/tag（npm 包已发布）

## Checklist / 检查清单

- [x] 标题符合 `Add owner/repo to Category` 约定
- [x] `README.md` 和 `README.zh.md` 已同步添加一行，格式 `| [owner/repo](link) | description | ⭐ |`
- [x] 星数已核实（HTML 页实测；0 为真实实测值，非空缺）
- [x] 无重复条目（两份 README 均检索确认不存在）
- [x] 一个 PR 只添加一个项目
- [x] 已给本仓库点 Star ⭐

## Additional Notes / 备注

- 本行追加在该分区表格末尾（流行度/字母序由维护者调整）；同一分区内其他 PerryLink 条目将分独立 PR 逐个提交，避免一个 PR 多项目。

## Summary by Sourcery

Add dsh-background-agents to the Tools, Workflows & Presets catalog.

New Features:
- Add PerryLink/dsh-background-agents to the Tools, Workflows & Presets catalog with its verified repository link, description, installation command, and star count in both English and Chinese READMEs.

Documentation:
- Update the bilingual README catalog entries to document the dsh-background-agents plugin.