### PR TITLE
Add PerryLink/dsh-library to Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The hottest category — giving text-only models "eyes."
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | A unified agent memory workspace for human and agent | 131 |
 | [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | Manual budget-targeted context compression: the conversation model picks the ranges to summarize and a cheap flash-tier route writes the checkpoint summaries; `dsh plugin add dsh-squeeze-command` | 0 |
 | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | Bounded, layered, approval-gated cross-session memory for dsh with frozen snapshot injection (`dsh plugin --profile web add dsh-memento`) | 85 |
+| [PerryLink/dsh-library](https://github.com/PerryLink/dsh-library) | Local document knowledge base: hybrid semantic+keyword search, citation-aware injection and retrieval diagnostics (`dsh plugin --profile web add dsh-library`) | 7 |
 
 ### 🎨 Web UI, Skins & Desktop Pets
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -92,6 +92,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [Ariestar/sivtr](https://github.com/Ariestar/sivtr) | 人与 agent 的统一记忆工作区 | 131 |
 | [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) | 手动、面向预算的上下文压缩:对话模型圈定要总结的范围,廉价 flash 级路由生成检查点摘要;`dsh plugin add dsh-squeeze-command` | 0 |
 | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | dsh 有界分层、审批门控、可审计的跨会话记忆，支持冻结快照注入（`dsh plugin --profile web add dsh-memento` 安装） | 85 |
+| [PerryLink/dsh-library](https://github.com/PerryLink/dsh-library) | 本地文档知识库：语义+关键词混合检索、引用感知注入与检索诊断（`dsh plugin --profile web add dsh-library` 安装） | 7 |
 
 ### 🎨 Web UI、皮肤与桌面宠物
 


### PR DESCRIPTION
## Project / 项目

| Field | Value |
| --- | --- |
| **Repo** | `PerryLink/dsh-library` → https://github.com/PerryLink/dsh-library |
| **Category** | 🧠 Memory |
| **Stars (verified)** | 7（2026-09-13 gh api repos/PerryLink/dsh-library stargazers_count 实测） |
| **Language (EN)** | Local document knowledge base: hybrid semantic+keyword search, citation-aware injection and retrieval diagnostics (`dsh plugin --profile web add dsh-library`) |
| **Language (ZH)** | 本地文档知识库：语义+关键词混合检索、引用感知注入与检索诊断（`dsh plugin --profile web add dsh-library` 安装） |

> ⚠️ **Bilingual required / 双语必填**：本 PR 同时更新 `README.md` 与 `README.zh.md` 同一分类的同一位置。

## Relationship to DSH / 与 DSH 的关系

DSH plugin: package.json declares the dsh.bundle manifest ("dsh": {"bundle": {"patch": "./cordis.patch.yml"}}) with cordis.patch.yml shipped in the repo; installed via the command in the description; the repository carries the dsh-plugin topic.

## Install & Verification / 安装与验证

```bash
dsh plugin --profile web add dsh-library
```

- [x] 已本地验证安装成功 / Verified locally
- [x] 仓库已打 `dsh-plugin` topic（2026-09-13 live 复核）
- [x] 含 LICENSE 与 README / Has LICENSE & README（Apache-2.0）
- [x] 已发布版本 Tag / Has release/tag（npm 包已发布）

## Checklist / 检查清单

- [x] 标题符合 `Add owner/repo to Category` 约定
- [x] `README.md` 和 `README.zh.md` 已同步添加一行，格式 `| [owner/repo](link) | description | ⭐ |`
- [x] 星数已核实（HTML 页实测；0 为真实实测值，非空缺）
- [x] 无重复条目（两份 README 均检索确认不存在）
- [x] 一个 PR 只添加一个项目
- [x] 已给本仓库点 Star ⭐

## Additional Notes / 备注

- 本行追加在该分区表格末尾（流行度/字母序由维护者调整）；同一分区内其他 PerryLink 条目将分独立 PR 逐个提交，避免一个 PR 多项目。

## Summary by Sourcery

Add dsh-library to the Memory project listings.

New Features:
- Add PerryLink/dsh-library to the Memory category in both English and Chinese project lists.

Documentation:
- Document the project’s local document knowledge-base capabilities and installation command in both README files.