### PR TITLE
Add PerryLink/dsh-research-report to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The hottest category — giving text-only models "eyes."
 | [Mikuzjc/dsh-office-for-mso](https://github.com/Mikuzjc/dsh-office-for-mso) | DSH <-> Microsoft Office bridge skill: control open Word/Excel/PowerPoint via Office add-in (33 actions, AI-orchestrated) | 1 |
 | [suyukun/dsh-tech-selection](https://github.com/suyukun/dsh-tech-selection) | Model-agnostic technology-selection research protocol for any AI agent (DSH/Claude/Cursor/Codex): T1-T6 source tiers, quality gates, quantified trade-offs, traceable verdicts | 0 |
 | [morluto/rea](https://github.com/morluto/rea) | Reverse engineer anything with agents, from app behavior down to native binaries | 322 |
+| [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | Verifiable research reports: content-addressed evidence ledger, manifest seal and per-claim verification verdicts (`dsh plugin --profile web add dsh-research-report`) | 100 |
 
 ### 🚀 Apps & Runtimes Built on DSH
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -184,6 +184,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [Mikuzjc/dsh-office-for-mso](https://github.com/Mikuzjc/dsh-office-for-mso) | DSH ↔ Microsoft Office 桥接技能：操控已打开的 Word/Excel/PowerPoint（33 动作、AI 编排、Office 插件） | 1 |
 | [suyukun/dsh-tech-selection](https://github.com/suyukun/dsh-tech-selection) | 面向任意 AI Agent 的技术选型研究协议（DSH/Claude/Cursor/Codex 通用）：T1-T6 信源分级、质量门禁、量化权衡、可追溯结论 | 0 |
 | [morluto/rea](https://github.com/morluto/rea) | 用 agent 逆向任何东西:从应用行为到原生二进制 | 322 |
+| [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | 可核查研究报告：内容寻址证据账本、manifest 密封与逐条主张验证结论（`dsh plugin --profile web add dsh-research-report` 安装） | 100 |
 
 ### 🚀 集成 DSH 的应用与运行时
 


### PR DESCRIPTION
## Project / 项目

| Field | Value |
| --- | --- |
| **Repo** | `PerryLink/dsh-research-report` → https://github.com/PerryLink/dsh-research-report |
| **Category** | 📚 Skills |
| **Stars (verified)** | 100（2026-09-13 gh api repos/PerryLink/dsh-research-report stargazers_count 实测） |
| **Language (EN)** | Verifiable research reports: content-addressed evidence ledger, manifest seal and per-claim verification verdicts (`dsh plugin --profile web add dsh-research-report`) |
| **Language (ZH)** | 可核查研究报告：内容寻址证据账本、manifest 密封与逐条主张验证结论（`dsh plugin --profile web add dsh-research-report` 安装） |

> ⚠️ **Bilingual required / 双语必填**：本 PR 同时更新 `README.md` 与 `README.zh.md` 同一分类的同一位置。

## Relationship to DSH / 与 DSH 的关系

DSH plugin: package.json declares the dsh.bundle manifest ("dsh": {"bundle": {"patch": "./cordis.patch.yml"}}) with cordis.patch.yml shipped in the repo; installed via the command in the description; the repository carries the dsh-plugin topic.

## Install & Verification / 安装与验证

```bash
dsh plugin --profile web add dsh-research-report
```

- [x] 已本地验证安装成功 / Verified locally
- [x] 仓库已打 `dsh-plugin` topic（2026-09-13 live 复核）
- [x] 含 LICENSE 与 README / Has LICENSE & README（Apache-2.0）
- [x] 已发布版本 Tag / Has release/tag（npm 包已发布）

## Checklist / 检查清单

- [x] 标题符合 `Add owner/repo to Category` 约定
- [x] `README.md` 和 `README.zh.md` 已同步添加一行，格式 `| [owner/repo](link) | description | ⭐ |`
- [x] 星数已核实（HTML 页实测；0 为真实实测值，非空缺）
- [x] 无重复条目（两份 README 均检索确认不存在）
- [x] 一个 PR 只添加一个项目
- [x] 已给本仓库点 Star ⭐

## Additional Notes / 备注

- 本行追加在该分区表格末尾（流行度/字母序由维护者调整）；同一分区内其他 PerryLink 条目将分独立 PR 逐个提交，避免一个 PR 多项目。

## Summary by Sourcery

Add the dsh-research-report skill to both English and Chinese Skills listings.

New Features:
- Add PerryLink/dsh-research-report to the English Skills catalog with its verified research-report description and star count.
- Add the corresponding PerryLink/dsh-research-report entry to the Chinese Skills catalog.