### PR TITLE
Add PerryLink/dsh-session-pin to Web UI, Skins & Desktop Pets

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The hottest category — giving text-only models "eyes."
 | [zizaiwo/dsh_plugins](https://github.com/zizaiwo/dsh_plugins) | Sidebar session categories for dsh Web UI: zero-config takeover of official workspace browser, organize sessions by custom folders (drag & drop, in-category creation, per-workspace isolation) | 0 |
 | [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) | Quick-prompts bar above composer: per-category snippet chips, orange {{placeholder}} highlighting, two-column management, per-session category memory | 0 |
 | [Moonshile/moonshile-dsh-plugins](https://github.com/Moonshile/moonshile-dsh-plugins) | Re-sorts sidebar workspaces by last activity once per day; stable order within the day | 0 |
+| [PerryLink/dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) | Pin sessions and workspaces in the Web sidebar with per-pin colors plus a navigation organizer (`dsh plugin --profile web add dsh-session-pin`) | 7 |
 ### 🖥️ TUI & Desktop
 
 | Project | Description | ⭐ |

--- a/README.zh.md
+++ b/README.zh.md
@@ -110,6 +110,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [zizaiwo/dsh_plugins](https://github.com/zizaiwo/dsh_plugins) | dsh 侧边栏会话分类插件：零配置接管官方工作区浏览器，按自定义分类文件夹管理会话（拖拽归类/分类内建会话/每工作区独立） | 0 |
 | [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) | 输入框上方的快捷指令胶囊栏：按分类存常用 prompt，橙色高亮占位符，两栏管理，分类记忆按会话独立持久化 | 0 |
 | [Moonshile/moonshile-dsh-plugins](https://github.com/Moonshile/moonshile-dsh-plugins) | 侧边栏工作区每日按最近活动排序一次，当天顺序稳定 | 0 |
+| [PerryLink/dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) | 会话与工作区置顶：每 pin 换色 + 导航组织器（`dsh plugin --profile web add dsh-session-pin` 安装） | 7 |
 
 ### 🖥️ TUI 与桌面端
 


### PR DESCRIPTION
## Project / 项目

| Field | Value |
| --- | --- |
| **Repo** | `PerryLink/dsh-session-pin` → https://github.com/PerryLink/dsh-session-pin |
| **Category** | 🎨 Web UI, Skins & Desktop Pets |
| **Stars (verified)** | 7（2026-09-13 gh api repos/PerryLink/dsh-session-pin stargazers_count 实测） |
| **Language (EN)** | Pin sessions and workspaces in the Web sidebar with per-pin colors plus a navigation organizer (`dsh plugin --profile web add dsh-session-pin`) |
| **Language (ZH)** | 会话与工作区置顶：每 pin 换色 + 导航组织器（`dsh plugin --profile web add dsh-session-pin` 安装） |

> ⚠️ **Bilingual required / 双语必填**：本 PR 同时更新 `README.md` 与 `README.zh.md` 同一分类的同一位置。

## Relationship to DSH / 与 DSH 的关系

DSH plugin: package.json declares the dsh.bundle manifest ("dsh": {"bundle": {"patch": "./cordis.patch.yml"}}) with cordis.patch.yml shipped in the repo; installed via the command in the description; the repository carries the dsh-plugin topic.

## Install & Verification / 安装与验证

```bash
dsh plugin --profile web add dsh-session-pin
```

- [x] 已本地验证安装成功 / Verified locally
- [x] 仓库已打 `dsh-plugin` topic（2026-09-13 live 复核）
- [x] 含 LICENSE 与 README / Has LICENSE & README（Apache-2.0）
- [x] 已发布版本 Tag / Has release/tag（npm 包已发布）

## Checklist / 检查清单

- [x] 标题符合 `Add owner/repo to Category` 约定
- [x] `README.md` 和 `README.zh.md` 已同步添加一行，格式 `| [owner/repo](link) | description | ⭐ |`
- [x] 星数已核实（HTML 页实测；0 为真实实测值，非空缺）
- [x] 无重复条目（两份 README 均检索确认不存在）
- [x] 一个 PR 只添加一个项目
- [x] 已给本仓库点 Star ⭐

## Additional Notes / 备注

- 本行追加在该分区表格末尾（流行度/字母序由维护者调整）；同一分区内其他 PerryLink 条目将分独立 PR 逐个提交，避免一个 PR 多项目。

## Summary by Sourcery

List the dsh-session-pin plugin in the Web UI project catalog with synchronized bilingual documentation.

Enhancements:
- Add PerryLink/dsh-session-pin to the Web UI, Skins & Desktop Pets project listings in both English and Chinese READMEs.

Documentation:
- Document the session and workspace pinning plugin, including per-pin colors, navigation organization, installation command, and verified star count.