### PR TITLE
Add PerryLink/dsh-click to TUI & Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The hottest category — giving text-only models "eyes."
 | [ChisaAlter/Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | Electron desktop shell for the DSH web UI, with themes & backgrounds | 74 |
 | [Ruler4396/dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Lightweight Windows launcher: silent autostart + WebView2 window | 87 |
 | [Jensen-Yao/dsh-plus-plus](https://github.com/Jensen-Yao/dsh-plus-plus) | Windows WPF desktop console for `dsh web`: one-click start/stop, phone URL over Wi-Fi/domain/Tailscale, firewall rule, storage locations, live logs, dark/light themes | 0 |
+| [PerryLink/dsh-click](https://github.com/PerryLink/dsh-click) | Windows-first desktop control tools: screenshots, accessibility trees, click/type/scroll and app launch, approval-gated (`dsh plugin --profile web add dsh-click`) | 7 |
 
 ### 🧩 Tools, Workflows & Presets
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -124,6 +124,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [ChisaAlter/Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | DSH Web UI 的 Electron 桌面壳,支持主题与背景图 | 74 |
 | [Ruler4396/dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows 轻量启动器:开机静默自启 + WebView2 窗口 | 87 |
 | [Jensen-Yao/dsh-plus-plus](https://github.com/Jensen-Yao/dsh-plus-plus) | Windows WPF 桌面控制台：一键启停 dsh web、手机入口（同一 Wi-Fi/自定义域名/Tailscale）、防火墙放行、存储位置管理与实时日志，深浅双主题 | 0 |
+| [PerryLink/dsh-click](https://github.com/PerryLink/dsh-click) | Windows 优先的桌面控制工具：截图、无障碍树、点击/输入/滚动与应用启动，审批门控（`dsh plugin --profile web add dsh-click` 安装） | 7 |
 
 ### 🧩 工具、工作流与预设
 


### PR DESCRIPTION
## Project / 项目

| Field | Value |
| --- | --- |
| **Repo** | `PerryLink/dsh-click` → https://github.com/PerryLink/dsh-click |
| **Category** | 🖥️ TUI & Desktop |
| **Stars (verified)** | 7（2026-09-13 gh api repos/PerryLink/dsh-click stargazers_count 实测） |
| **Language (EN)** | Windows-first desktop control tools: screenshots, accessibility trees, click/type/scroll and app launch, approval-gated (`dsh plugin --profile web add dsh-click`) |
| **Language (ZH)** | Windows 优先的桌面控制工具：截图、无障碍树、点击/输入/滚动与应用启动，审批门控（`dsh plugin --profile web add dsh-click` 安装） |

> ⚠️ **Bilingual required / 双语必填**：本 PR 同时更新 `README.md` 与 `README.zh.md` 同一分类的同一位置。

## Relationship to DSH / 与 DSH 的关系

DSH plugin: package.json declares the dsh.bundle manifest ("dsh": {"bundle": {"patch": "./cordis.patch.yml"}}) with cordis.patch.yml shipped in the repo; installed via the command in the description; the repository carries the dsh-plugin topic.

## Install & Verification / 安装与验证

```bash
dsh plugin --profile web add dsh-click
```

- [x] 已本地验证安装成功 / Verified locally
- [x] 仓库已打 `dsh-plugin` topic（2026-09-13 live 复核）
- [x] 含 LICENSE 与 README / Has LICENSE & README（Apache-2.0）
- [x] 已发布版本 Tag / Has release/tag（npm 包已发布）

## Checklist / 检查清单

- [x] 标题符合 `Add owner/repo to Category` 约定
- [x] `README.md` 和 `README.zh.md` 已同步添加一行，格式 `| [owner/repo](link) | description | ⭐ |`
- [x] 星数已核实（HTML 页实测；0 为真实实测值，非空缺）
- [x] 无重复条目（两份 README 均检索确认不存在）
- [x] 一个 PR 只添加一个项目
- [x] 已给本仓库点 Star ⭐

## Additional Notes / 备注

- 本行追加在该分区表格末尾（流行度/字母序由维护者调整）；同一分区内其他 PerryLink 条目将分独立 PR 逐个提交，避免一个 PR 多项目。

## Summary by Sourcery

Add the dsh-click desktop control plugin to the bilingual TUI and Desktop catalogs.

New Features:
- Add PerryLink/dsh-click to the TUI & Desktop project listings in both English and Chinese READMEs.

Documentation:
- Document the Windows-first desktop control plugin, including its supported interactions and installation command, in the corresponding bilingual category tables.