### PR TITLE
Add zhengjy01/dsh-restart to Tools, Workflows & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The hottest category — giving text-only models "eyes."
 | [PerryLink/dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) | TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint | 0 |
 | [PerryLink/dsh-wechat](https://github.com/PerryLink/dsh-wechat) | Bridges WeChat private messages to DSH with two-way text, image, file, and media transfer | 0 |
 | [zhengjy01/dsh-qqbot-panel](https://github.com/zhengjy01/dsh-qqbot-panel) | Visual web settings panel for the official @tencent-connect/dsh-qqbot plugin (credentials, access modes/allowlists, workspace picker, scan-to-bind). | 0 |
+| [zhengjy01/dsh-restart](https://github.com/zhengjy01/dsh-restart) | One-click restart for DeepSeek Harness: a web restart button plus a `dsh_restart` agent tool hand the relaunch to a detached helper, the page auto-reconnects, and a recovery console shows boot errors when the new host fails (`dsh plugin --profile web add @zhengjunyao/dsh-restart`) | 0 |
 
 ### 📚 Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -164,6 +164,7 @@ DeepSeek Harness 是 DeepSeek AI 开源的 agent harness。它的核心哲学是
 | [PerryLink/dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) | TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点 | 0 |
 | [PerryLink/dsh-wechat](https://github.com/PerryLink/dsh-wechat) | 将微信私聊消息桥接到 DSH，支持文本、图片、文件与音视频双向传输 | 0 |
 | [zhengjy01/dsh-qqbot-panel](https://github.com/zhengjy01/dsh-qqbot-panel) | 官方 @tencent-connect/dsh-qqbot 插件的可视化 Web 设置面板（凭据、访问模式/白名单、工作区选择、扫码绑定）。 | 0 |
+| [zhengjy01/dsh-restart](https://github.com/zhengjy01/dsh-restart) | DeepSeek Harness 一键重启：网页重启按钮与 `dsh_restart` Agent 工具把重启交给独立 helper，页面自动重连，新宿主启动失败时由恢复控制台显示启动错误（`dsh plugin --profile web add @zhengjunyao/dsh-restart`） | 0 |
 
 ### 📚 Skills 与技能包
 


### PR DESCRIPTION
Adds one entry to both `README.md` and `README.zh.md` (bilingual, same category/position).

- **Project**: [zhengjy01/dsh-restart](https://github.com/zhengjy01/dsh-restart)
- **Relation to DSH**: a restart button for the DSH web GUI. Installing/updating a plugin only takes effect in a fresh `dsh web` process; this plugin makes that a one-click action (settings card + sidebar entry + `dsh_restart` / `dsh_restart_status` agent tools), relaunches the exact same command through a detached helper, auto-reconnects the page, and shows boot errors in a recovery console when the new host fails.
- **Install**: `dsh plugin --profile web add @zhengjunyao/dsh-restart`
- **npm**: `@zhengjunyao/dsh-restart` 0.1.1 (latest)
- **License**: MIT
- **`dsh-plugin` topic**: set (`deepseek-harness`, `devtools`, `dsh`, `dsh-plugin`, `restart`)
- **No duplicate**: `zhengjy01/dsh-restart` did not appear in either README before this PR; existing `dsh-restart*` entries are different repositories by other owners.

Only new lines are added — the diff is pure insertions (one row per README).

## Summary by Sourcery

List the zhengjy01/dsh-restart plugin in the bilingual tool directories.

New Features:
- Add the zhengjy01/dsh-restart plugin to the Tools, Workflows & Presets listings in both English and Chinese README files.

Documentation:
- Document the plugin’s one-click DSH web GUI restart capability and installation command in both language-specific README files.